### PR TITLE
Grappling Struts (Open) artwork missing and allows for barrel rolls while landed

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using System.Linq;
-using SubPhases;
-using Tokens;
+﻿using Actions;
 using ActionsList;
-using GameModes;
 using Arcs;
-using Actions;
-using Editions;
 using BoardTools;
+using Editions;
+using SubPhases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tokens;
 
 namespace Ship
 {
@@ -349,6 +346,11 @@ namespace Ship
                     AvailableActionsList.Add(action);
                 }
             }
+        }
+
+        public void RemoveAvailableAction(Type ActionType)
+        {
+            AvailableActionsList.RemoveAll(action => action.GetType().Equals(ActionType));
         }
 
         public void AddAvailableFreeAction(GenericAction action)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/GrapplingStruts.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/GrapplingStruts.cs
@@ -1,4 +1,4 @@
-﻿using BoardTools;
+﻿using ActionsList;
 using Obstacles;
 using Ship;
 using SubPhases;
@@ -24,6 +24,8 @@ namespace UpgradesList.SecondEdition
 
             AnotherSide = typeof(GrapplingStrutsOpen);
             SelectSideOnSetup = false;
+
+            ImageUrl = "https://infinitearenas.com/xw2/images/upgrades/grapplingstruts.png";
         }
     }
 
@@ -43,6 +45,8 @@ namespace UpgradesList.SecondEdition
             );
 
             AnotherSide = typeof(GrapplingStrutsClosed);
+
+            ImageUrl = "https://infinitearenas.com/xw2/images/upgrades/grapplingstruts-sideb.png";
         }
     }
 }
@@ -138,24 +142,24 @@ namespace Abilities.SecondEdition
             IgnoreObstaclesList.AddRange(HostShip.ObstaclesLanded);
 
             HostShip.IgnoreObstaclesList.AddRange(IgnoreObstaclesList);
-            HostShip.OnCheckIgnoreObstaclesDuringBarrelRoll += Allow;
 
             HostShip.OnManeuverIsRevealed += CheckSpecialManeuvers;
             HostShip.OnMovementFinish += FlipThisCard;
+            HostShip.OnGenerateActions += DisallowBarrelRoll;
         }
 
         public override void DeactivateAbility()
         {
             HostShip.OnManeuverIsRevealed -= CheckSpecialManeuvers;
             HostShip.OnMovementFinish -= FlipThisCard;
+            HostShip.OnGenerateActions -= DisallowBarrelRoll;
 
             HostShip.IgnoreObstaclesList.RemoveAll(n => IgnoreObstaclesList.Contains(n));
-            HostShip.OnCheckIgnoreObstaclesDuringBarrelRoll -= Allow;
         }
 
-        private void Allow(ref bool isAllowed)
+        private void DisallowBarrelRoll(GenericShip ship)
         {
-            isAllowed = true;
+            HostShip.RemoveAvailableAction(typeof(BarrelRollAction));
         }
 
         private void FlipThisCard(GenericShip ship)


### PR DESCRIPTION
Closes #104 

Added new method to GenericShipActions to suppress actions after generation. Used this method in Grappling Struts (Open) to disallow barrel rolls while active. ImageUrls updated.