### PR TITLE
Update Unity Analytics package to 5.1.1 to resolve crash on exit error.

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,6 +11,7 @@
     "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.purchasing": "4.11.0",
     "com.unity.remote-config": "4.0.0",
+    "com.unity.services.analytics": "5.1.1",
     "com.unity.services.cloud-diagnostics": "1.0.10",
     "com.unity.test-framework": "1.3.9",
     "com.unity.timeline": "1.8.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -111,13 +111,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.analytics": {
-      "version": "4.4.0",
-      "depth": 1,
+      "version": "5.1.1",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.ugui": "1.0.0",
-        "com.unity.services.core": "1.8.1",
-        "com.unity.nuget.newtonsoft-json": "3.0.2"
+        "com.unity.services.core": "1.12.5",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
To test, build for your current platform, open game, and click Quit. Should be no error after updating package.

Unsure if error exists in other platforms other than Windows although those are the only identified platforms at this time.