### PR TITLE
Ionization Ruleset now sets IsIonManeuver

### DIFF
--- a/Assets/Scripts/Model/Rules/RulesList/IonizationRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/IonizationRule.cs
@@ -35,6 +35,8 @@ namespace RulesList
         {
             if (BoardTools.Board.IsOffTheBoard(ship)) return;
 
+            ship.AssignedManeuver.IsIonManeuver = true;
+
             ship.OnMovementExecuted -= RegisterRemoveIonization;
 
             Triggers.RegisterTrigger(new Trigger


### PR DESCRIPTION
Confirm that effects relying on an Ion Maneuver work. You can use the Debug console to assign Disabled Power Regulator.