### PR TITLE
Twice Broken Trust

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/FO/XiClassLightShuttle/AgentTierny.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/FO/XiClassLightShuttle/AgentTierny.cs
@@ -126,15 +126,14 @@ namespace Conditions
             Host.OnAttackStartAsAttacker += CheckAlliedStress;
             GenericShip.OnFaceupCritCardReadyToBeDealtGlobal += CheckRemoveBrokenTrust;
             Host.OnAttackFinish += CheckRemoveBrokenTrust;
-            Host.OnAttackFinishAsAttacker += CheckRemoveBrokenTrust;
         }
-
+        
         public override void WhenRemoved()
         {
             Host.OnCheckIsFriendly -= TreatAsAllied;
             Host.OnAttackStartAsAttacker -= CheckAlliedStress;
             GenericShip.OnFaceupCritCardReadyToBeDealtGlobal -= CheckRemoveBrokenTrust;
-            Host.OnAttackFinishAsAttacker -= CheckRemoveBrokenTrust;
+            Host.OnAttackFinish -= CheckRemoveBrokenTrust;
         }
 
         public void CheckRemoveBrokenTrust(GenericShip ship)


### PR DESCRIPTION
Agent Tierny's Broken Trust's WhenRemoved() method delegates didn't match the WhenAssigned() delegates leading to a null reference when the condition was to be removed.

Closes #124.