### PR TITLE
163 cutthroat recharging proton cannons

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/ProtonCannons.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/ProtonCannons.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-using Arcs;
-using Upgrade;
+﻿using Arcs;
 using System;
+using System.Collections.Generic;
+using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
@@ -22,16 +22,14 @@ namespace UpgradesList.SecondEdition
                     minRange: 2,
                     maxRange: 3,
                     charges: 2,
+                    chargesCost: 2,
                     regensCharges: true,
                     arc: ArcType.Bullseye
                 ),
                 abilityType: typeof(Abilities.SecondEdition.ProtonCannonsAbility)
-
             );
-
-
-            ImageUrl = "https://infinitearenas.com/xw2/images/upgrades/protoncannons.png";
         }
+
         public override void PayAttackCost(Action callBack) { callBack(); }
     }
 }
@@ -48,7 +46,7 @@ namespace Abilities.SecondEdition
                 GetDiceModificationAiPriority,
                 DiceModificationType.Change,
                 1,
-                new List<DieSide>() { DieSide.Focus, DieSide.Success  },
+                new List<DieSide>() { DieSide.Focus, DieSide.Success },
                 DieSide.Crit,
                 payAbilityCost: payCharges
             );
@@ -61,10 +59,9 @@ namespace Abilities.SecondEdition
 
         private void payCharges(Action<bool> callback)
         {
-            if (HostUpgrade.State.Charges > 1)
+            if (HostUpgrade.State.Charges >= HostUpgrade.UpgradeInfo.WeaponInfo.ChargesCost)
             {
-                HostUpgrade.State.SpendCharge();
-                HostUpgrade.State.SpendCharge();
+                HostUpgrade.State.SpendCharges(HostUpgrade.UpgradeInfo.WeaponInfo.ChargesCost);
                 callback(true);
             }
             else
@@ -81,7 +78,7 @@ namespace Abilities.SecondEdition
 
             if (Combat.ChosenWeapon != HostUpgrade) result = false;
 
-            if (HostUpgrade.State.Charges < 2) result = false;
+            if (HostUpgrade.State.Charges < HostUpgrade.UpgradeInfo.WeaponInfo.ChargesCost) result = false;
 
             return result;
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Cutthroat.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Cutthroat.cs
@@ -20,8 +20,6 @@ namespace UpgradesList.SecondEdition
                 abilityType: typeof(Abilities.SecondEdition.CutthroatAbility),
                 restriction: new FactionRestriction(Faction.Scum)
             );
-
-            ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/fd/7b/fd7b2ccc-d500-4a02-bb2a-9e0538406d65/swz85_upgrade_cutthroat.png";
         }        
     }
 }
@@ -72,8 +70,10 @@ namespace Abilities.SecondEdition
         {
             foreach (GenericUpgrade upgrade in HostShip.UpgradeBar.GetUpgradesAll())
             {
+                bool hasRegen = upgrade.UpgradeInfo.RegensChargesCount > 0 || ((upgrade.UpgradeInfo.WeaponInfo)?.RegensCharges ?? false);
+
                 if (upgrade.State.MaxCharges > 0
-                    && upgrade.UpgradeInfo.RegensChargesCount == 0
+                    && !hasRegen
                     && upgrade.State.Charges < upgrade.State.MaxCharges
                     && !upgrade.UpgradeInfo.CannotBeRecharged
                 )

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Cutthroat.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Cutthroat.cs
@@ -40,8 +40,9 @@ namespace Abilities.SecondEdition
 
         private void CheckAbility(GenericShip ship, bool flag)
         {
+            if (HostShip == ship) return;
             if (!Tools.IsAnotherFriendly(HostShip, ship)) return;
-            if (!ship.PilotInfo.IsLimited && !ship.UpgradeBar.HasUpgradeInstalled(typeof(Cutthroat))) return;
+            if (!(ship.PilotInfo.IsLimited || ship.UpgradeBar.HasUpgradeInstalled(typeof(Cutthroat)))) return;
             
             DistanceInfo distanceInfo = new DistanceInfo(HostShip, ship);
             if (distanceInfo.Range > 3) return;
@@ -70,10 +71,8 @@ namespace Abilities.SecondEdition
         {
             foreach (GenericUpgrade upgrade in HostShip.UpgradeBar.GetUpgradesAll())
             {
-                bool hasRegen = upgrade.UpgradeInfo.RegensChargesCount > 0 || ((upgrade.UpgradeInfo.WeaponInfo)?.RegensCharges ?? false);
-
                 if (upgrade.State.MaxCharges > 0
-                    && !hasRegen
+                    && !UpgradeHasRegen(upgrade)
                     && upgrade.State.Charges < upgrade.State.MaxCharges
                     && !upgrade.UpgradeInfo.CannotBeRecharged
                 )
@@ -118,9 +117,9 @@ namespace Abilities.SecondEdition
             foreach (GenericUpgrade upgrade in HostShip.UpgradeBar.GetUpgradesAll())
             {
                 if (upgrade.State.MaxCharges > 0
-                    && upgrade.UpgradeInfo.RegensChargesCount == 0
                     && upgrade.State.Charges < upgrade.State.MaxCharges
                     && !upgrade.UpgradeInfo.CannotBeRecharged
+                    && !UpgradeHasRegen(upgrade)
                 )
                 {
                     subphase.AddDecision(
@@ -161,6 +160,11 @@ namespace Abilities.SecondEdition
             DecisionSubPhase.ConfirmDecisionNoCallback();
             upgrade.State.RestoreCharges(1);
             Triggers.FinishTrigger();
+        }
+
+        private bool UpgradeHasRegen(GenericUpgrade upgrade)
+        {
+            return upgrade.UpgradeInfo.RegensChargesCount > 0 || ((upgrade.UpgradeInfo.WeaponInfo)?.RegensCharges ?? false);
         }
 
         private class CutthroatDecisionSubphase : DecisionSubPhase { }


### PR DESCRIPTION
Updated Cutthroat HasUpgradeToRecharge check to exclude upgrades with WeaponInfo blocks which have Regen (i.e. Proton Cannon). Minor cleanup for Proton Cannon and Cutthroat.