### PR TITLE
Automated Target Priority fix

### DIFF
--- a/Assets/Scripts/Model/Ai/Aggressor/TargetingSubSystem/TargetingSubSystem.cs
+++ b/Assets/Scripts/Model/Ai/Aggressor/TargetingSubSystem/TargetingSubSystem.cs
@@ -142,6 +142,11 @@ namespace AI.Aggressor
 
             foreach (GenericShip enemyShip in GetEnemyShipsAndDistance(CurrentShip, inArcAndRange: true))
             {
+                bool isAllowedByAbility = true;
+                ship.CallTargetForAttackIsAllowed(enemyShip, ref isAllowedByAbility);
+
+                if (!isAllowedByAbility) continue;
+
                 Selection.AnotherShip = enemyShip;
                 foreach (IShipWeapon weapon in CurrentShip.GetAllWeapons())
                 {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Tech/AutomatedTargetPriority.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Tech/AutomatedTargetPriority.cs
@@ -61,9 +61,14 @@ namespace Abilities.SecondEdition
                 }
             }
 
-            if (Combat.ShotInfo.Range > minRange)
+            DistanceInfo targetRange = new(HostShip, target);
+
+            if (targetRange.Range > minRange)
             {
-                Messages.ShowError($"Automated Target Priority: You must attack target at range {minRange} instead");
+                if (HostShip.Owner.PlayerType != Players.PlayerType.Ai)
+                {
+                    Messages.ShowError($"Automated Target Priority: You must attack target at range {minRange} instead");
+                }
                 isAllowed = false;
             }
         }


### PR DESCRIPTION
Updated AI Attack Decisions to check if target is a valid attack target before adding that particular decision; modified Automated Target Priority to not display an error message for AI, and to use ShotInfo instead of Combat.ShotInfo when determining viability as Combat may not have been started yet.

Closes #121 