### PR TITLE
Update vectored cannons canonical

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
@@ -27,6 +27,7 @@ namespace UpgradesList.SecondEdition
                 abilityType: typeof(Abilities.SecondEdition.VectoredCannonsRZ1Ability),
                 isStandardazed: true
             );
+            NameCanonical = "vectoredcannonsrz1";
 
             ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/b0/1a/b01a4dff-267b-436c-a719-878335302bca/swz83_upgrade_vectoredcannonsrz1.png";
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
@@ -28,8 +28,6 @@ namespace UpgradesList.SecondEdition
                 isStandardazed: true
             );
             NameCanonical = "vectoredcannonsrz1";
-
-            ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/b0/1a/b01a4dff-267b-436c-a719-878335302bca/swz83_upgrade_vectoredcannonsrz1.png";
         }
     }
 }


### PR DESCRIPTION
Just ran into this while I was playing with some XWA bits, couldn't import a squad with Wedgelet having Vectored Cannons. I thought we'd had an issue about Vectored Cannons previously but I couldn't see it in the list, guess it got fixed, or I imagined it...