### PR TITLE
TIE Bomber expansion pilots

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -1,4 +1,6 @@
-﻿using Content;
+﻿using Actions;
+using ActionsList;
+using Content;
 using System.Collections.Generic;
 using Upgrade;
 using UpgradesList.SecondEdition;
@@ -39,9 +41,10 @@ namespace Ship
                 MustHaveUpgrades.Add(typeof(ProtonBombs));
                 MustHaveUpgrades.Add(typeof(TopCover));
 
-                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png";
+                ShipInfo.ActionIcons.RemoveActions(typeof(ReloadAction));
+                ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(ReloadAction), ActionColor.White));
 
-                IsWIP = true;
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -58,8 +58,8 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            HostShip.OnBombWasDropped += CheckAbilityOnDrop;
-            HostShip.OnBombWasLaunched += CheckAbilityOnLaunch;
+            HostShip.OnBombWasDropped -= CheckAbilityOnDrop;
+            HostShip.OnBombWasLaunched -= CheckAbilityOnLaunch;
         }
 
         private void CheckAbilityOnDrop()

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -10,19 +10,23 @@ namespace Ship
         {
             public CaptainJonusTBE() : base()
             {
-                PilotInfo = new PilotCardInfo(
+                PilotInfo = new PilotCardInfo25(
                     "Captain Jonus",
+                    "Top Cover",
+                    Faction.Imperial,
                     4,
-                    36,
+                    5,
+                    loadoutValue:0,
+                    isStandardLayout:true,
                      tags: new List<Tags>
                     {
-                        Tags.LsL
+                        Tags.Tie
                     },
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.CaptainJonusTBEAbility),
                     extraUpgradeIcon: UpgradeType.Talent
                 );
-                PilotNameCanonical = "captainjonus-swz98-lsl";
+                PilotNameCanonical = "captainjonus-swz98";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -40,6 +40,8 @@ namespace Ship
                 MustHaveUpgrades.Add(typeof(TopCover));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png";
+
+                IsWIP = true;
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -9,7 +9,7 @@ namespace Ship
     {
         public class CaptainJonusTBE : TIESaBomber
         {
-            public CaptainJonusTBE() 
+            public CaptainJonusTBE()
             {
                 PilotInfo = new PilotCardInfo25(
                     "Captain Jonus",
@@ -17,8 +17,8 @@ namespace Ship
                     Faction.Imperial,
                     4,
                     5,
-                    loadoutValue:0,
-                    isStandardLayout:true,
+                    loadoutValue: 0,
+                    isStandardLayout: true,
                     tags: new List<Tags>
                     {
                         Tags.Tie
@@ -29,13 +29,15 @@ namespace Ship
                     {
                         UpgradeType.Talent,
                         UpgradeType.Missile,
+                        UpgradeType.Missile,
                         UpgradeType.Device
                     }
                 );
                 PilotNameCanonical = "captainjonus-swz98";
-                
+
                 MustHaveUpgrades.Add(typeof(BarrageRockets));
                 MustHaveUpgrades.Add(typeof(ProtonBombs));
+                MustHaveUpgrades.Add(typeof(TopCover));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png";
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -1,0 +1,64 @@
+﻿using Content;
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+    namespace SecondEdition.TIESaBomber
+    {
+        public class CaptainJonusTBE : TIESaBomber
+        {
+            public CaptainJonusTBE() : base()
+            {
+                PilotInfo = new PilotCardInfo(
+                    "Captain Jonus",
+                    4,
+                    36,
+                     tags: new List<Tags>
+                    {
+                        Tags.LsL
+                    },
+                    isLimited: true,
+                    abilityType: typeof(Abilities.SecondEdition.CaptainJonusTBEAbility),
+                    extraUpgradeIcon: UpgradeType.Talent
+                );
+                PilotNameCanonical = "captainjonus-swz98-lsl";
+            }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    //After you drop or launch a device, gain an evade token.
+    public class CaptainJonusTBEAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnBombWasDropped += CheckAbilityOnDrop;
+            HostShip.OnBombWasLaunched += CheckAbilityOnLaunch;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnBombWasDropped += CheckAbilityOnDrop;
+            HostShip.OnBombWasLaunched += CheckAbilityOnLaunch;
+        }
+
+        private void CheckAbilityOnDrop()
+        {
+            RegisterAbilityTrigger(TriggerTypes.OnBombWasDropped, GetEvadeToken);
+        }
+
+        private void CheckAbilityOnLaunch()
+        {
+            RegisterAbilityTrigger(TriggerTypes.OnBombWasLaunched, GetEvadeToken);
+        }
+
+        private void GetEvadeToken(object sender, System.EventArgs e)
+        {
+            Messages.ShowInfo(HostShip.PilotInfo.PilotName + " gains Evade token");
+            HostShip.Tokens.AssignToken(typeof(Tokens.EvadeToken), Triggers.FinishTrigger);
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs
@@ -1,6 +1,7 @@
 ﻿using Content;
 using System.Collections.Generic;
 using Upgrade;
+using UpgradesList.SecondEdition;
 
 namespace Ship
 {
@@ -8,7 +9,7 @@ namespace Ship
     {
         public class CaptainJonusTBE : TIESaBomber
         {
-            public CaptainJonusTBE() : base()
+            public CaptainJonusTBE() 
             {
                 PilotInfo = new PilotCardInfo25(
                     "Captain Jonus",
@@ -18,15 +19,25 @@ namespace Ship
                     5,
                     loadoutValue:0,
                     isStandardLayout:true,
-                     tags: new List<Tags>
+                    tags: new List<Tags>
                     {
                         Tags.Tie
                     },
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.CaptainJonusTBEAbility),
-                    extraUpgradeIcon: UpgradeType.Talent
+                    extraUpgradeIcons: new List<UpgradeType>
+                    {
+                        UpgradeType.Talent,
+                        UpgradeType.Missile,
+                        UpgradeType.Device
+                    }
                 );
                 PilotNameCanonical = "captainjonus-swz98";
+                
+                MustHaveUpgrades.Add(typeof(BarrageRockets));
+                MustHaveUpgrades.Add(typeof(ProtonBombs));
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/CaptainJonusTBE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 489b3abbc6cf9d442b90af09113e0de0

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -14,8 +14,10 @@ namespace Ship
     {
         public class DeathfireTBE : TIESaBomber
         {
-            public DeathfireTBE() 
+            public DeathfireTBE()
             {
+                //TODO Standard points vs XWA points
+
                 PilotInfo = new PilotCardInfo25(
                     "\"Deathfire\"",
                     "Obstinate Bombardier",
@@ -40,7 +42,7 @@ namespace Ship
                     }
                 );
                 PilotNameCanonical = "deathfire-swz98";
-                
+
                 MustHaveUpgrades.Add(typeof(ProtonBombs));
                 MustHaveUpgrades.Add(typeof(ConnerNets));
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -38,7 +38,7 @@ namespace Ship
                         UpgradeType.Device,
                         UpgradeType.Device
                     },
-                    legality:new List<Legality> {Legality.StandardLegal, Legality.ExtendedLegal}
+                    legality: new List<Legality> { Legality.StandardLegal, Legality.ExtendedLegal }
                 );
                 PilotNameCanonical = "deathfire-swz98";
 
@@ -47,16 +47,18 @@ namespace Ship
                 MustHaveUpgrades.Add(typeof(SwiftApproach));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/deathfire-swz98.png";
+
+                IsWIP = true;
             }
         }
 
         public class DeathfireTBEXWA : DeathfireTBE
         {
-            public DeathfireTBEXWA(): base()
+            public DeathfireTBEXWA() : base()
             {
-                var pilot = (PilotCardInfo25) PilotInfo;
+                var pilot = (PilotCardInfo25)PilotInfo;
                 pilot.Cost = 4;
-                pilot.LegalityInfo = new List<Legality> {Legality.XWA};
+                pilot.LegalityInfo = new List<Legality> { Legality.XWA };
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -6,6 +6,7 @@ using Ship;
 using SubPhases;
 using System.Collections.Generic;
 using Upgrade;
+using UpgradesList.SecondEdition;
 
 namespace Ship
 {
@@ -13,7 +14,7 @@ namespace Ship
     {
         public class DeathfireTBE : TIESaBomber
         {
-            public DeathfireTBE() : base()
+            public DeathfireTBE() 
             {
                 PilotInfo = new PilotCardInfo25(
                     "\"Deathfire\"",
@@ -30,9 +31,20 @@ namespace Ship
                     charges: 2,
                     regensCharges: 1,
                     isLimited: true,
-                    abilityType: typeof(Abilities.SecondEdition.DeathfireTBEAbility)
+                    abilityType: typeof(Abilities.SecondEdition.DeathfireTBEAbility),
+                    extraUpgradeIcons: new List<UpgradeType>
+                    {
+                        UpgradeType.Talent,
+                        UpgradeType.Device,
+                        UpgradeType.Device
+                    }
                 );
                 PilotNameCanonical = "deathfire-swz98";
+                
+                MustHaveUpgrades.Add(typeof(ProtonBombs));
+                MustHaveUpgrades.Add(typeof(ConnerNets));
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/deathfire-swz98.png";
             }
         }
     }
@@ -44,7 +56,6 @@ namespace Abilities.SecondEdition
     //you may spend 2 charges to drop or launch a bomb using the 3 forward template.
     public class DeathfireTBEAbility : GenericAbility
     {
-
         public override void ActivateAbility()
         {
             HostShip.OnMovementFinish += CheckAbility;
@@ -60,8 +71,7 @@ namespace Abilities.SecondEdition
             //AI doesn't use ability
             if (HostShip.Owner.UsesHotacAiRules) return;
 
-            if (HostShip.AssignedManeuver.Speed >= 3
-                && HostShip.AssignedManeuver.Speed <= 5
+            if (HostShip.AssignedManeuver.Speed is >= 3 and <= 5
                 && !HostShip.IsBumped && HostShip.State.Charges > 1
                 && !HostShip.IsBombAlreadyDropped)
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -44,6 +44,7 @@ namespace Ship
 
                 MustHaveUpgrades.Add(typeof(ProtonBombs));
                 MustHaveUpgrades.Add(typeof(ConnerNets));
+                MustHaveUpgrades.Add(typeof(SwiftApproach));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/deathfire-swz98.png";
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -23,7 +23,7 @@ namespace Ship
                     "Obstinate Bombardier",
                     Faction.Imperial,
                     2,
-                    4,
+                    3,
                     loadoutValue: 0,
                     isStandardLayout: true,
                     tags: new List<Tags>
@@ -39,7 +39,8 @@ namespace Ship
                         UpgradeType.Talent,
                         UpgradeType.Device,
                         UpgradeType.Device
-                    }
+                    },
+                    legality:new List<Legality> {Legality.StandardLegal, Legality.ExtendedLegal}
                 );
                 PilotNameCanonical = "deathfire-swz98";
 
@@ -47,6 +48,16 @@ namespace Ship
                 MustHaveUpgrades.Add(typeof(ConnerNets));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/deathfire-swz98.png";
+            }
+        }
+
+        public class DeathfireTBEXWA : DeathfireTBE
+        {
+            public DeathfireTBEXWA(): base()
+            {
+                var pilot = (PilotCardInfo25) PilotInfo;
+                pilot.Cost = 4;
+                pilot.LegalityInfo = new List<Legality> {Legality.XWA};
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -1,0 +1,113 @@
+﻿using BoardTools;
+using Bombs;
+using Content;
+using Movement;
+using Ship;
+using SubPhases;
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+    namespace SecondEdition.TIESaBomber
+    {
+        public class DeathfireTBE : TIESaBomber
+        {
+            public DeathfireTBE() : base()
+            {
+                PilotInfo = new PilotCardInfo(
+                    "\"Deathfire\"",
+                    2,
+                    33,
+                     tags: new List<Tags>
+                    {
+                        Tags.LsL
+                    },
+                    charges: 2,
+                    regensCharges: 1,
+                    isLimited: true,
+                    abilityType: typeof(Abilities.SecondEdition.DeathfireTBEAbility)
+                );
+                PilotNameCanonical = "deathfire-swz98-lsl";
+            }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    //After you fully execute a speed 3-5 maneuver, if you have not dropped or launched a device this round,
+    //you may spend 2 charges to drop or launch a bomb using the 3 forward template.
+    public class DeathfireTBEAbility : GenericAbility
+    {
+
+        public override void ActivateAbility()
+        {
+            HostShip.OnMovementFinish += CheckAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnMovementFinish -= CheckAbility;
+        }
+
+        private void CheckAbility(GenericShip ship)
+        {
+            //AI doesn't use ability
+            if (HostShip.Owner.UsesHotacAiRules) return;
+
+            if (HostShip.AssignedManeuver.Speed >= 3
+                && HostShip.AssignedManeuver.Speed <= 5
+                && !HostShip.IsBumped && HostShip.State.Charges > 1
+                && !HostShip.IsBombAlreadyDropped)
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnMovementFinish, AskUseAbility);
+            }
+        }
+
+        private void AskUseAbility(object sender, System.EventArgs e)
+        {
+            AskToUseAbility
+            (
+                descriptionShort: HostShip.PilotInfo.PilotName,
+                descriptionLong: "Do you want to spend 2 charges to drop or launch a bomb using the [3] template?",
+                useByDefault: NeverUseByDefault,
+                useAbility: DropBomb,
+                imageHolder: HostUpgrade
+            );
+        }
+
+        private void DropBomb(object sender, System.EventArgs e)
+        {
+            DecisionSubPhase.ConfirmDecisionNoCallback();
+
+            HostShip.SpendCharges(2);
+
+            HostShip.OnGetAvailableBombDropTemplatesNoConditions += AddDropTemplate;
+            HostShip.OnGetAvailableBombLaunchTemplates += AddLaunchTemplate;
+
+            BombsManager.RegisterBombDropTriggerIfAvailable(
+                HostShip,
+                TriggerTypes.OnAbilityDirect,
+                subType: UpgradeSubType.Bomb,
+                isRealDrop: false
+            );
+
+            Triggers.ResolveTriggers(TriggerTypes.OnAbilityDirect, Triggers.FinishTrigger);
+        }
+
+        private void AddDropTemplate(List<ManeuverTemplate> availableTemplates, GenericUpgrade upgrade)
+        {
+            if (upgrade.UpgradeInfo.SubType != UpgradeSubType.Bomb) return;
+            availableTemplates.Clear();
+            availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed3, isBombTemplate: true));
+        }
+
+        protected virtual void AddLaunchTemplate(List<ManeuverTemplate> availableTemplates, GenericUpgrade upgrade)
+        {
+            if (upgrade.UpgradeInfo.SubType != UpgradeSubType.Bomb) return;
+            availableTemplates.Clear();
+            availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed3));
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -15,20 +15,24 @@ namespace Ship
         {
             public DeathfireTBE() : base()
             {
-                PilotInfo = new PilotCardInfo(
+                PilotInfo = new PilotCardInfo25(
                     "\"Deathfire\"",
+                    "Obstinate Bombardier",
+                    Faction.Imperial,
                     2,
-                    33,
-                     tags: new List<Tags>
+                    4,
+                    loadoutValue: 0,
+                    isStandardLayout: true,
+                    tags: new List<Tags>
                     {
-                        Tags.LsL
+                        Tags.Tie
                     },
                     charges: 2,
                     regensCharges: 1,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.DeathfireTBEAbility)
                 );
-                PilotNameCanonical = "deathfire-swz98-lsl";
+                PilotNameCanonical = "deathfire-swz98";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -16,8 +16,6 @@ namespace Ship
         {
             public DeathfireTBE()
             {
-                //TODO Standard points vs XWA points
-
                 PilotInfo = new PilotCardInfo25(
                     "\"Deathfire\"",
                     "Obstinate Bombardier",

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 777acac2b6c5417438fd67cae1b48d7e

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -12,19 +12,23 @@ namespace Ship
         {
             public MajorRhymerTBE() : base()
             {
-                PilotInfo = new PilotCardInfo(
+                PilotInfo = new PilotCardInfo25(
                     "Major Rhymer",
+                    "Precision Destruction",
+                    Faction.Imperial,
                     4,
-                    33,
+                    5,
+                    loadoutValue:0,
+                    isStandardLayout: true,
                      tags: new List<Tags>
                     {
-                        Tags.LsL
+                        Tags.Tie
                     },
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.MajorRhymerTBEAbility),
                     extraUpgradeIcon: UpgradeType.Talent
                 );
-                PilotNameCanonical = "majorrhymer-swz98-lsl";
+                PilotNameCanonical = "majorrhymer-swz98";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -1,0 +1,73 @@
+﻿using Arcs;
+using Content;
+using Ship;
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+    namespace SecondEdition.TIESaBomber
+    {
+        public class MajorRhymerTBE : TIESaBomber
+        {
+            public MajorRhymerTBE() : base()
+            {
+                PilotInfo = new PilotCardInfo(
+                    "Major Rhymer",
+                    4,
+                    33,
+                     tags: new List<Tags>
+                    {
+                        Tags.LsL
+                    },
+                    isLimited: true,
+                    abilityType: typeof(Abilities.SecondEdition.MajorRhymerTBEAbility),
+                    extraUpgradeIcon: UpgradeType.Talent
+                );
+                PilotNameCanonical = "majorrhymer-swz98-lsl";
+            }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    //While you perform a Torpedo attack, if the defender is in your bullseye, change 1 Focus result to a Crit result.
+    public class MajorRhymerTBEAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            AddDiceModification(
+                HostShip.PilotInfo.PilotName,
+                IsDiceModificationAvailable,
+                GetDiceModificationAiPriority,
+                DiceModificationType.Change,
+                1,
+                new List<DieSide>() { DieSide.Focus },
+                DieSide.Crit
+            );
+        }
+
+        public override void DeactivateAbility()
+        {
+            RemoveDiceModification();
+        }
+
+        private bool IsDiceModificationAvailable()
+        {
+            return (Combat.AttackStep == CombatStep.Attack
+                && Combat.Attacker == HostShip
+                && Combat.ChosenWeapon.WeaponType == WeaponTypes.Torpedo
+                && Combat.DiceRollAttack.Focuses > 0
+                && Combat.Attacker.SectorsInfo.IsShipInSector(Combat.Defender, ArcType.Bullseye)
+            );
+        }
+
+        private int GetDiceModificationAiPriority()
+        {
+            return 70;
+        }
+
+
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -38,6 +38,7 @@ namespace Ship
                 
                 MustHaveUpgrades.Add(typeof(AdvProtonTorpedoes));
                 MustHaveUpgrades.Add(typeof(AfterBurners));
+                MustHaveUpgrades.Add(typeof(AutomatedLoaders));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/majorrhymer-swz98.png";
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -11,15 +11,17 @@ namespace Ship
     {
         public class MajorRhymerTBE : TIESaBomber
         {
-            public MajorRhymerTBE() 
+            public MajorRhymerTBE()
             {
+                //TODO Standard points vs XWA points
+
                 PilotInfo = new PilotCardInfo25(
                     "Major Rhymer",
                     "Precision Destruction",
                     Faction.Imperial,
                     4,
                     5,
-                    loadoutValue:0,
+                    loadoutValue: 0,
                     isStandardLayout: true,
                     tags: new List<Tags>
                     {
@@ -35,7 +37,7 @@ namespace Ship
                     }
                 );
                 PilotNameCanonical = "majorrhymer-swz98";
-                
+
                 MustHaveUpgrades.Add(typeof(AdvProtonTorpedoes));
                 MustHaveUpgrades.Add(typeof(AfterBurners));
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -20,7 +20,7 @@ namespace Ship
                     "Precision Destruction",
                     Faction.Imperial,
                     4,
-                    5,
+                    4,
                     loadoutValue: 0,
                     isStandardLayout: true,
                     tags: new List<Tags>
@@ -34,7 +34,8 @@ namespace Ship
                         UpgradeType.Torpedo,
                         UpgradeType.Modification,
                         UpgradeType.Modification
-                    }
+                    },
+                    legality: new List<Legality> {Legality.StandardLegal, Legality.ExtendedLegal}
                 );
                 PilotNameCanonical = "majorrhymer-swz98";
 
@@ -42,6 +43,16 @@ namespace Ship
                 MustHaveUpgrades.Add(typeof(AfterBurners));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/majorrhymer-swz98.png";
+            }
+        }
+
+        public class MajorRhymerTBEXWA : MajorRhymerTBE
+        {
+            public MajorRhymerTBEXWA(): base()
+            {
+                var pilot = (PilotCardInfo25) PilotInfo;
+                pilot.Cost = 5;
+                pilot.LegalityInfo = new List<Legality> {Legality.XWA};
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -13,8 +13,6 @@ namespace Ship
         {
             public MajorRhymerTBE()
             {
-                //TODO Standard points vs XWA points
-
                 PilotInfo = new PilotCardInfo25(
                     "Major Rhymer",
                     "Precision Destruction",

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs
@@ -3,6 +3,7 @@ using Content;
 using Ship;
 using System.Collections.Generic;
 using Upgrade;
+using UpgradesList.SecondEdition;
 
 namespace Ship
 {
@@ -10,7 +11,7 @@ namespace Ship
     {
         public class MajorRhymerTBE : TIESaBomber
         {
-            public MajorRhymerTBE() : base()
+            public MajorRhymerTBE() 
             {
                 PilotInfo = new PilotCardInfo25(
                     "Major Rhymer",
@@ -20,15 +21,25 @@ namespace Ship
                     5,
                     loadoutValue:0,
                     isStandardLayout: true,
-                     tags: new List<Tags>
+                    tags: new List<Tags>
                     {
                         Tags.Tie
                     },
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.MajorRhymerTBEAbility),
-                    extraUpgradeIcon: UpgradeType.Talent
+                    extraUpgradeIcons: new List<UpgradeType>
+                    {
+                        UpgradeType.Torpedo,
+                        UpgradeType.Modification,
+                        UpgradeType.Modification
+                    }
                 );
                 PilotNameCanonical = "majorrhymer-swz98";
+                
+                MustHaveUpgrades.Add(typeof(AdvProtonTorpedoes));
+                MustHaveUpgrades.Add(typeof(AfterBurners));
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/majorrhymer-swz98.png";
             }
         }
     }
@@ -71,7 +82,5 @@ namespace Abilities.SecondEdition
         {
             return 70;
         }
-
-
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/MajorRhymerTBE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02f5d681e55cac645b2ab64c54742413

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
@@ -41,6 +41,7 @@ namespace Ship
                 
                 MustHaveUpgrades.Add(typeof(PlasmaTorpedoes));
                 MustHaveUpgrades.Add(typeof(IonBombs));
+                MustHaveUpgrades.Add(typeof(TrueGrit));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tomaxbren-swz98.png";
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
@@ -4,6 +4,7 @@ using Ship;
 using System;
 using System.Collections.Generic;
 using Upgrade;
+using UpgradesList.SecondEdition;
 
 namespace Ship
 {
@@ -11,7 +12,7 @@ namespace Ship
     {
         public class TomaxBrenTBE : TIESaBomber
         {
-            public TomaxBrenTBE() : base()
+            public TomaxBrenTBE() 
             {
                 PilotInfo = new PilotCardInfo25(
                     "Tomax Bren",
@@ -21,7 +22,7 @@ namespace Ship
                     4,
                     loadoutValue: 0,
                     isStandardLayout: true,
-                     tags: new List<Tags>
+                    tags: new List<Tags>
                     {
                         Tags.Tie
                     },
@@ -29,9 +30,19 @@ namespace Ship
                     charges: 2,
                     regensCharges: 1,
                     abilityType: typeof(Abilities.SecondEdition.TomaxBrenTBEAbility),
-                    extraUpgradeIcon: UpgradeType.Talent
+                    extraUpgradeIcons: new List<UpgradeType>
+                    {
+                        UpgradeType.Talent,
+                        UpgradeType.Torpedo,
+                        UpgradeType.Device
+                    }
                 );
                 PilotNameCanonical = "tomaxbren-swz98";
+                
+                MustHaveUpgrades.Add(typeof(PlasmaTorpedoes));
+                MustHaveUpgrades.Add(typeof(IonBombs));
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tomaxbren-swz98.png";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
@@ -44,8 +44,6 @@ namespace Ship
                 MustHaveUpgrades.Add(typeof(TrueGrit));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tomaxbren-swz98.png";
-
-                IsWIP = true;
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
@@ -1,0 +1,90 @@
+﻿using ActionsList;
+using Content;
+using Ship;
+using System;
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+    namespace SecondEdition.TIESaBomber
+    {
+        public class TomaxBrenTBE : TIESaBomber
+        {
+            public TomaxBrenTBE() : base()
+            {
+                PilotInfo = new PilotCardInfo(
+                    "Tomax Bren",
+                    5,
+                    38,
+                     tags: new List<Tags>
+                    {
+                        Tags.LsL
+                    },
+                    isLimited: true,
+                    charges: 2,
+                    regensCharges: 1,
+                    abilityType: typeof(Abilities.SecondEdition.TomaxBrenTBEAbility),
+                    extraUpgradeIcon: UpgradeType.Talent
+                );
+                PilotNameCanonical = "tomaxbren-swz98-lsl";
+            }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    //After you perform a Barrel Roll action, you may spend 2 charges. If you do, gain a focus token.
+    public class TomaxBrenTBEAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnActionIsPerformed += CheckConditions;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnActionIsPerformed -= CheckConditions;
+        }
+
+        private void CheckConditions(GenericAction action)
+        {
+            if (action is BarrelRollAction && HostShip.State.Charges > 1)
+            {
+                HostShip.OnActionDecisionSubphaseEnd += RegisterActionTrigger;
+            }
+        }
+
+        private void RegisterActionTrigger(GenericShip ship)
+        {
+            HostShip.OnActionDecisionSubphaseEnd -= RegisterActionTrigger;
+
+            RegisterAbilityTrigger(TriggerTypes.OnFreeAction, AskToUseOwnAbility);
+        }
+
+        private void AskToUseOwnAbility(object sender, EventArgs e)
+        {
+            AskToUseAbility(
+                HostShip.PilotInfo.PilotName,
+                NeverUseByDefault,
+                ActivateOwnAbility,
+                descriptionLong: "Do you want to spend 2 charges to gain a focus token?",
+                imageHolder: HostUpgrade
+            );
+        }
+
+        private void ActivateOwnAbility(object sender, EventArgs e)
+        {
+            SubPhases.DecisionSubPhase.ConfirmDecisionNoCallback();
+
+            HostShip.Tokens.AssignToken(typeof(Tokens.FocusToken), Cleanup);
+        }
+
+        private void Cleanup()
+        {
+            HostShip.SpendCharges(2);
+            Triggers.FinishTrigger();
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
@@ -13,13 +13,17 @@ namespace Ship
         {
             public TomaxBrenTBE() : base()
             {
-                PilotInfo = new PilotCardInfo(
+                PilotInfo = new PilotCardInfo25(
                     "Tomax Bren",
+                    "Scimitar Veteran",
+                    Faction.Imperial,
                     5,
-                    38,
+                    4,
+                    loadoutValue: 0,
+                    isStandardLayout: true,
                      tags: new List<Tags>
                     {
-                        Tags.LsL
+                        Tags.Tie
                     },
                     isLimited: true,
                     charges: 2,
@@ -27,7 +31,7 @@ namespace Ship
                     abilityType: typeof(Abilities.SecondEdition.TomaxBrenTBEAbility),
                     extraUpgradeIcon: UpgradeType.Talent
                 );
-                PilotNameCanonical = "tomaxbren-swz98-lsl";
+                PilotNameCanonical = "tomaxbren-swz98";
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs
@@ -12,7 +12,7 @@ namespace Ship
     {
         public class TomaxBrenTBE : TIESaBomber
         {
-            public TomaxBrenTBE() 
+            public TomaxBrenTBE()
             {
                 PilotInfo = new PilotCardInfo25(
                     "Tomax Bren",
@@ -38,12 +38,14 @@ namespace Ship
                     }
                 );
                 PilotNameCanonical = "tomaxbren-swz98";
-                
+
                 MustHaveUpgrades.Add(typeof(PlasmaTorpedoes));
                 MustHaveUpgrades.Add(typeof(IonBombs));
                 MustHaveUpgrades.Add(typeof(TrueGrit));
 
                 ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tomaxbren-swz98.png";
+
+                IsWIP = true;
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/TomaxBrenTBE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14bed371fd5276b49a3766764b0e6367

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
@@ -1,0 +1,83 @@
+﻿using Abilities;
+using ActionsList;
+using Analytics;
+using Ship;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class AutomatedLoaders : GenericUpgrade
+    {
+        public AutomatedLoaders()
+        {
+            UpgradeInfo = new UpgradeCardInfo(
+                "Automated Loaders", 
+                UpgradeType.Modification,
+                cost: 0,
+                abilityType: typeof(Abilities.SecondEdition.AutomatedLoadersAbility),
+                charges: 1
+            );
+
+            IsWIP = true; // Mark as Work In Progress if applicable
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class AutomatedLoadersAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnAttackFinishAsAttacker += CheckAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnAttackFinishAsAttacker -= CheckAbility;
+        }
+
+        private void CheckAbility(GenericShip ship)
+        {
+            if (Combat.ShotInfo.Weapon.WeaponType != WeaponTypes.PrimaryWeapon) return;
+
+            RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AskUseAbility);
+        }
+
+        private void AskUseAbility(object sender, EventArgs e)
+        {
+            HostShip.BeforeActionIsPerformed += RegisterSpendChargeTrigger;
+            HostShip.AskPerformFreeAction(
+                new ReloadAction() {CanBePerformedWhileStressed = false},
+                CleanUp,
+                HostUpgrade.UpgradeInfo.Name,
+                "After you perform a primary attack you may spend 1 Charge to perform a Reload action.",
+                HostUpgrade
+            );
+        }
+
+        private void RegisterSpendChargeTrigger(GenericAction action, ref bool isFreeAction)
+        {
+            HostShip.BeforeActionIsPerformed -= RegisterSpendChargeTrigger;
+            RegisterAbilityTrigger(
+                TriggerTypes.OnFreeAction,
+                delegate
+                {
+                    HostUpgrade.State.SpendCharge();
+                    Triggers.FinishTrigger();
+                }
+            );
+        }
+        
+        private void CleanUp()
+        {
+            HostShip.BeforeActionIsPerformed -= RegisterSpendChargeTrigger;
+            Triggers.FinishTrigger();
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
@@ -1,6 +1,7 @@
 ﻿using ActionsList;
 using Ship;
 using System;
+using System.Linq;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
@@ -42,7 +43,7 @@ namespace Abilities.SecondEdition
         {
             if (Combat.ShotInfo.Weapon.WeaponType != WeaponTypes.PrimaryWeapon) return;
 
-            if (HostUpgrade.UpgradeInfo.Charges > 0)
+            if (HostUpgrade.UpgradeInfo.Charges > 0 && HostShip.UpgradeBar.GetRechargableUpgrades().Any())
             {
                 RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AskUseAbility);
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
@@ -1,7 +1,6 @@
 ﻿using ActionsList;
 using Ship;
 using System;
-using System.Linq;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
@@ -11,7 +10,7 @@ namespace UpgradesList.SecondEdition
         public AutomatedLoaders()
         {
             UpgradeInfo = new UpgradeCardInfo(
-                "Automated Loaders", 
+                "Automated Loaders",
                 UpgradeType.Modification,
                 cost: 0,
                 abilityType: typeof(Abilities.SecondEdition.AutomatedLoadersAbility),
@@ -19,6 +18,8 @@ namespace UpgradesList.SecondEdition
             );
 
             IsWIP = true; // Mark as Work In Progress if applicable
+
+            ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/majorrhymer-swz98.png";
         }
     }
 }
@@ -49,9 +50,9 @@ namespace Abilities.SecondEdition
             HostShip.BeforeActionIsPerformed += RegisterSpendChargeTrigger;
 
             //TODO Would be neat if this could check whether any ordnance upgrades are currently reloadable
-            
+
             HostShip.AskPerformFreeAction(
-                new ReloadAction() {CanBePerformedWhileStressed = false},
+                new ReloadAction() { CanBePerformedWhileStressed = false },
                 CleanUp,
                 HostUpgrade.UpgradeInfo.Name,
                 "After you perform a primary attack you may spend 1 Charge to perform a Reload action.",
@@ -71,7 +72,7 @@ namespace Abilities.SecondEdition
                 }
             );
         }
-        
+
         private void CleanUp()
         {
             HostShip.BeforeActionIsPerformed -= RegisterSpendChargeTrigger;

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
@@ -1,12 +1,7 @@
-﻿using Abilities;
-using ActionsList;
-using Analytics;
+﻿using ActionsList;
 using Ship;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
@@ -52,6 +47,9 @@ namespace Abilities.SecondEdition
         private void AskUseAbility(object sender, EventArgs e)
         {
             HostShip.BeforeActionIsPerformed += RegisterSpendChargeTrigger;
+
+            //TODO Would be neat if this could check whether any ordnance upgrades are currently reloadable
+            
             HostShip.AskPerformFreeAction(
                 new ReloadAction() {CanBePerformedWhileStressed = false},
                 CleanUp,

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
@@ -51,13 +51,17 @@ namespace Abilities.SecondEdition
 
             //TODO Would be neat if this could check whether any ordnance upgrades are currently reloadable
 
-            HostShip.AskPerformFreeAction(
-                new ReloadAction() { CanBePerformedWhileStressed = false },
-                CleanUp,
-                HostUpgrade.UpgradeInfo.Name,
-                "After you perform a primary attack you may spend 1 Charge to perform a Reload action.",
-                HostUpgrade
-            );
+            if (HostUpgrade.UpgradeInfo.Charges > 0)
+            {
+                HostShip.AskPerformFreeAction(
+                    new ReloadAction() { CanBePerformedWhileStressed = false },
+                    CleanUp,
+                    HostUpgrade.UpgradeInfo.Name,
+                    "After you perform a primary attack you may spend 1 Charge to perform a Reload action.",
+                    HostUpgrade
+                );
+            }
+
         }
 
         private void RegisterSpendChargeTrigger(GenericAction action, ref bool isFreeAction)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs
@@ -42,7 +42,10 @@ namespace Abilities.SecondEdition
         {
             if (Combat.ShotInfo.Weapon.WeaponType != WeaponTypes.PrimaryWeapon) return;
 
-            RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AskUseAbility);
+            if (HostUpgrade.UpgradeInfo.Charges > 0)
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AskUseAbility);
+            }
         }
 
         private void AskUseAbility(object sender, EventArgs e)
@@ -51,17 +54,14 @@ namespace Abilities.SecondEdition
 
             //TODO Would be neat if this could check whether any ordnance upgrades are currently reloadable
 
-            if (HostUpgrade.UpgradeInfo.Charges > 0)
-            {
-                HostShip.AskPerformFreeAction(
-                    new ReloadAction() { CanBePerformedWhileStressed = false },
-                    CleanUp,
-                    HostUpgrade.UpgradeInfo.Name,
-                    "After you perform a primary attack you may spend 1 Charge to perform a Reload action.",
-                    HostUpgrade
-                );
-            }
 
+            HostShip.AskPerformFreeAction(
+                new ReloadAction() { CanBePerformedWhileStressed = false },
+                CleanUp,
+                HostUpgrade.UpgradeInfo.Name,
+                "After you perform a primary attack you may spend 1 Charge to perform a Reload action.",
+                HostUpgrade
+            );
         }
 
         private void RegisterSpendChargeTrigger(GenericAction action, ref bool isFreeAction)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AutomatedLoaders.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c7080e02e46e014cbe24f7e85e3e2ba

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
@@ -1,0 +1,65 @@
+﻿using Abilities.SecondEdition;
+using ActionsList;
+using System;
+using System.Collections.Generic;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class SwiftApproach : GenericUpgrade
+    {
+        public SwiftApproach()
+        {
+            UpgradeInfo = new UpgradeCardInfo(
+                "Swift Approach",
+                UpgradeType.Talent,
+                cost: 0,
+                abilityType: typeof(SwiftApproachAbility)
+            );
+
+            IsHidden = true;
+
+            IsWIP = true;
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class SwiftApproachAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnBombWasDropped += CheckAbility;
+            HostShip.OnBombWasLaunched += CheckAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnBombWasDropped -= CheckAbility;
+            HostShip.OnBombWasLaunched -= CheckAbility;
+        }
+
+        private void CheckAbility()
+        {
+            if (Phases.CurrentPhase.Name != "System") return;
+
+            AskToPerformReposition();
+        }
+
+        private void AskToPerformReposition(object sender, EventArgs e)
+        {
+            HostShip.AskPerformFreeAction(
+                new List<GenericAction>()
+                {
+                    new BarrelRollAction(){CanBePerformedWhileStressed = true},
+                    new BoostAction(){CanBePerformedWhileStressed = true}
+                },
+                Triggers.FinishTrigger,
+                HostUpgrade.NamePostfix,
+                "After dropping or launching a device, you may perform a white Barrel Roll or Boost action",
+                HostShip
+            );
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
@@ -31,23 +31,30 @@ namespace Abilities.SecondEdition
     {
         public override void ActivateAbility()
         {
-            HostShip.OnBombWasDropped += CheckAbility;
-            HostShip.OnBombWasLaunched += CheckAbility;
+            HostShip.OnBombWasDropped += CheckDroppedAbility;
+            HostShip.OnBombWasLaunched += CheckLaunchedAbility;
         }
 
         public override void DeactivateAbility()
         {
-            HostShip.OnBombWasDropped -= CheckAbility;
-            HostShip.OnBombWasLaunched -= CheckAbility;
+            HostShip.OnBombWasDropped -= CheckDroppedAbility;
+            HostShip.OnBombWasLaunched -= CheckLaunchedAbility;
         }
 
-        private void CheckAbility()
+        private void CheckDroppedAbility()
         {
             if (Phases.CurrentPhase.Name != "Systems Phase") return;
 
             RegisterAbilityTrigger(TriggerTypes.OnBombWasDropped, AskToPerformReposition);
+        }
+
+        private void CheckLaunchedAbility()
+        {
+            if (Phases.CurrentPhase.Name != "Systems Phase") return;
+
             RegisterAbilityTrigger(TriggerTypes.OnBombWasLaunched, AskToPerformReposition);
         }
+
 
         private void AskToPerformReposition(object sender, EventArgs e)
         {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
@@ -1,8 +1,8 @@
 ﻿using Abilities.SecondEdition;
+using Actions;
 using ActionsList;
 using System;
 using System.Collections.Generic;
-using Actions;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
@@ -43,7 +43,7 @@ namespace Abilities.SecondEdition
 
         private void CheckAbility()
         {
-            if (Phases.CurrentPhase.Name != "System") return;
+            if (Phases.CurrentPhase.Name != "Systems Phase") return;
 
             RegisterAbilityTrigger(TriggerTypes.OnBombWasDropped, AskToPerformReposition);
             RegisterAbilityTrigger(TriggerTypes.OnBombWasLaunched, AskToPerformReposition);

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs
@@ -2,6 +2,7 @@
 using ActionsList;
 using System;
 using System.Collections.Generic;
+using Actions;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
@@ -44,7 +45,8 @@ namespace Abilities.SecondEdition
         {
             if (Phases.CurrentPhase.Name != "System") return;
 
-            AskToPerformReposition();
+            RegisterAbilityTrigger(TriggerTypes.OnBombWasDropped, AskToPerformReposition);
+            RegisterAbilityTrigger(TriggerTypes.OnBombWasLaunched, AskToPerformReposition);
         }
 
         private void AskToPerformReposition(object sender, EventArgs e)
@@ -52,8 +54,8 @@ namespace Abilities.SecondEdition
             HostShip.AskPerformFreeAction(
                 new List<GenericAction>()
                 {
-                    new BarrelRollAction(){CanBePerformedWhileStressed = true},
-                    new BoostAction(){CanBePerformedWhileStressed = true}
+                    new BarrelRollAction(){CanBePerformedWhileStressed = true, Color = ActionColor.White},
+                    new BoostAction(){CanBePerformedWhileStressed = true, Color = ActionColor.White}
                 },
                 Triggers.FinishTrigger,
                 HostUpgrade.NamePostfix,

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SwiftApproach.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c2d0c9e3d0c87946870ee2284d6dc02

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -41,7 +41,7 @@ namespace Abilities.SecondEdition
         private void CheckAbility(GenericShip ship)
         {
             if (Tools.IsFriendly(ship, HostShip)
-                && Board.IsShipBetweenRange(HostShip, ship, 0, 3)
+                && Board.IsShipBetweenRange(HostShip, ship, 0, 1)
                 && (Combat.Defender != null)
                 && Tools.IsSameShip(ship, Combat.Defender)
                // Needs a condition about whether a device has been dropped/launched

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -1,5 +1,10 @@
 ﻿using Abilities.SecondEdition;
-using System;
+using BoardTools;
+using Bombs;
+using Movement;
+using Ship;
+using SubPhases;
+using System.Collections.Generic;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
@@ -25,12 +30,63 @@ namespace Abilities.SecondEdition
     {
         public override void ActivateAbility()
         {
-            throw new NotImplementedException();
+            GenericShip.OnAttackFinishGlobal += CheckAbility;
         }
 
         public override void DeactivateAbility()
         {
-            throw new NotImplementedException();
+            GenericShip.OnAttackFinishGlobal -= CheckAbility;
         }
+
+        private void CheckAbility(GenericShip ship)
+        {
+            if (Tools.IsFriendly(ship, HostShip)
+                && Board.IsShipBetweenRange(HostShip, ship, 0, 3)
+                && (Combat.Defender != null)
+                && Tools.IsSameShip(ship, Combat.Defender)
+               // Needs a condition about whether a device has been dropped/launched
+               )
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AskUseAbility);
+            }
+        }
+
+        private void AskUseAbility(object sender, System.EventArgs e)
+        {
+            AskToUseAbility
+            (
+                descriptionShort: "Top Cover",
+                descriptionLong: "Do you want to launch a bomb using the [3] straight or bank template?",
+                useByDefault: NeverUseByDefault,
+                useAbility: DropBomb,
+                imageHolder: HostUpgrade
+            );
+        }
+
+        private void DropBomb(object sender, System.EventArgs e)
+        {
+            DecisionSubPhase.ConfirmDecisionNoCallback();
+
+            HostShip.OnGetAvailableBombLaunchTemplates += AddLaunchTemplates;
+
+            BombsManager.RegisterBombDropTriggerIfAvailable(
+                HostShip,
+                TriggerTypes.OnAbilityDirect,
+                subType: UpgradeSubType.Bomb,
+                isRealDrop: false
+            );
+
+            Triggers.ResolveTriggers(TriggerTypes.OnAbilityDirect, Triggers.FinishTrigger);
+        }
+
+        protected virtual void AddLaunchTemplates(List<ManeuverTemplate> availableTemplates, GenericUpgrade upgrade)
+        {
+            if (upgrade.UpgradeInfo.SubType != UpgradeSubType.Bomb) return;
+            availableTemplates.Clear();
+            availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed3));
+            availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Bank, ManeuverDirection.Left, ManeuverSpeed.Speed3));
+            availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Bank, ManeuverDirection.Right, ManeuverSpeed.Speed3));
+        }
+
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -4,6 +4,7 @@ using Bombs;
 using Movement;
 using Ship;
 using SubPhases;
+using System;
 using System.Collections.Generic;
 using Upgrade;
 
@@ -30,14 +31,33 @@ namespace Abilities.SecondEdition
 {
     public class TopCoverAbility : GenericAbility
     {
+        private bool deviceWasDroppedOrLaunched = false;
+
         public override void ActivateAbility()
         {
             GenericShip.OnAttackFinishGlobal += CheckAbility;
+            HostShip.OnBombWasDropped += SetBombFlag;
+            HostShip.OnBombWasLaunched += SetBombFlag;
+            HostShip.OnRoundEnd += ResetBombFlag;
+
         }
 
         public override void DeactivateAbility()
         {
             GenericShip.OnAttackFinishGlobal -= CheckAbility;
+            HostShip.OnBombWasDropped -= SetBombFlag;
+            HostShip.OnBombWasLaunched -= SetBombFlag;
+            HostShip.OnRoundEnd -= ResetBombFlag;
+        }
+
+        private void SetBombFlag()
+        {
+            deviceWasDroppedOrLaunched = true;
+        }
+
+        private void ResetBombFlag(GenericShip ship)
+        {
+            deviceWasDroppedOrLaunched = false;
         }
 
         private void CheckAbility(GenericShip ship)
@@ -45,7 +65,7 @@ namespace Abilities.SecondEdition
             if (Tools.IsFriendly(ship, HostShip)
                 && Board.IsShipBetweenRange(HostShip, ship, 0, 3)
                 && (Combat.Defender != null)
-               // Needs a condition about whether a device has been dropped/launched
+               && !deviceWasDroppedOrLaunched
                )
             {
                 RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AskUseAbility);

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -40,10 +40,9 @@ namespace Abilities.SecondEdition
 
         private void CheckAbility(GenericShip ship)
         {
-            if (Tools.IsFriendly(ship, HostShip)
-                && Board.IsShipBetweenRange(HostShip, ship, 0, 3)
+            if (Tools.IsFriendly(Combat.Defender, HostShip)
+                && Board.IsShipBetweenRange(HostShip, Combat.Defender, 0, 3)
                 && (Combat.Defender != null)
-                && Tools.IsSameShip(ship, Combat.Defender)
                // Needs a condition about whether a device has been dropped/launched
                )
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -1,0 +1,36 @@
+﻿using Abilities.SecondEdition;
+using System;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class TopCover : GenericUpgrade
+    {
+        public TopCover()
+        {
+            UpgradeInfo = new UpgradeCardInfo(
+                name: "Top Cover",
+                type: UpgradeType.Talent,
+                cost: 0,
+                abilityType: typeof(TopCoverAbility));
+            IsHidden = true;
+            IsWIP = true;
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class TopCoverAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DeactivateAbility()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -21,7 +21,7 @@ namespace UpgradesList.SecondEdition
             IsHidden = true;
             IsWIP = true;
 
-            ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png0;"
+            ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png";
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs
@@ -20,6 +20,8 @@ namespace UpgradesList.SecondEdition
                 abilityType: typeof(TopCoverAbility));
             IsHidden = true;
             IsWIP = true;
+
+            ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/captainjonus-swz98.png0;"
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TopCover.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 37ee863b1bda76a47811c893cc1b724b

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
@@ -1,13 +1,13 @@
-﻿using System;
+﻿using Abilities.SecondEdition;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Abilities.SecondEdition;
 using Tokens;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class TrueGrit: GenericUpgrade
+    public class TrueGrit : GenericUpgrade
     {
         public TrueGrit()
         {
@@ -21,13 +21,15 @@ namespace UpgradesList.SecondEdition
             IsHidden = true;
 
             IsWIP = true;
+
+            ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tomaxbren-swz98.png";
         }
     }
 }
 
 namespace Abilities.SecondEdition
 {
-    public class TrueGritAbility: GenericAbility
+    public class TrueGritAbility : GenericAbility
     {
         public override void ActivateAbility()
         {
@@ -44,7 +46,7 @@ namespace Abilities.SecondEdition
         {
             var tokens = HostShip.Tokens;
             if (tokens.HasToken<StrainToken>()) return;
-            
+
 
             if (tokens.GetNonLockRedOrangeTokens().Any())
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
@@ -1,4 +1,5 @@
 ﻿using Abilities.SecondEdition;
+using SubPhases;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,8 +20,6 @@ namespace UpgradesList.SecondEdition
             );
 
             IsHidden = true;
-
-            IsWIP = true;
 
             ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tomaxbren-swz98.png";
         }
@@ -91,7 +90,7 @@ namespace Abilities.SecondEdition
 
         private void Finish()
         {
-            Triggers.FinishTrigger();
+            DecisionSubPhase.ConfirmDecision();
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
@@ -1,21 +1,94 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Abilities.SecondEdition;
+using Tokens;
+using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class TrueGrit
+    public class TrueGrit: GenericUpgrade
     {
         public TrueGrit()
         {
-            
+            UpgradeInfo = new UpgradeCardInfo(
+                "True Grit",
+                UpgradeType.Talent,
+                cost: 0,
+                abilityType: typeof(TrueGritAbility)
+            );
+
+            IsHidden = true;
+
+            IsWIP = true;
         }
     }
 }
 
 namespace Abilities.SecondEdition
 {
-    
+    public class TrueGritAbility: GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            Phases.Events.OnActivationPhaseEnd_Triggers += CheckAbility;
+
+        }
+
+        public override void DeactivateAbility()
+        {
+            Phases.Events.OnActivationPhaseEnd_Triggers -= CheckAbility;
+        }
+
+        private void CheckAbility()
+        {
+            var tokens = HostShip.Tokens;
+            if (tokens.HasToken<StrainToken>()) return;
+            
+
+            if (tokens.GetNonLockRedOrangeTokens().Any())
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnAbilityDirect, AskUseAbility);
+            }
+        }
+
+        private void AskUseAbility(object sender, EventArgs e)
+        {
+            AskToUseAbility("True Grit", AlwaysUseByDefault, UseAbility,
+                descriptionLong:
+                "If you have no Strain tokens, you may gain 1 Strain token to discard a red non-Lock token or an orange token.");
+        }
+
+        private void UseAbility(object sender, EventArgs e)
+        {
+            IsAbilityUsed = true;
+            var tokens = HostShip.Tokens;
+
+            var decisions = new Dictionary<string, EventHandler>();
+            var tooltips = new Dictionary<string, string>();
+            foreach (var token in tokens.GetNonLockRedOrangeTokens())
+            {
+                decisions.Add(token.Name, delegate { DiscardToken(token); });
+                tooltips.Add(token.Name, $"Discard one {token.Name} token");
+            }
+
+            AskForDecision("Choose token to discard", "Select which token you want to discard",
+                decisions: decisions, tooltips: tooltips);
+        }
+
+        private void DiscardToken(GenericToken token)
+        {
+            HostShip.Tokens.RemoveToken(token, GainOneStrainToken);
+        }
+
+        private void GainOneStrainToken()
+        {
+            HostShip.Tokens.AssignToken(typeof(StrainToken), Finish);
+        }
+
+        private void Finish()
+        {
+            Triggers.FinishTrigger();
+        }
+    }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UpgradesList.SecondEdition
+{
+    public class TrueGrit
+    {
+        public TrueGrit()
+        {
+            
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs
@@ -83,6 +83,7 @@ namespace Abilities.SecondEdition
 
         private void GainOneStrainToken()
         {
+            // TODO Locks up here :-(
             HostShip.Tokens.AssignToken(typeof(StrainToken), Finish);
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/TrueGrit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 663f4ce4a5f82844a81811772c80cec0

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Torpedo/ProtonTorpedoes.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Torpedo/ProtonTorpedoes.cs
@@ -44,7 +44,7 @@ namespace Abilities.SecondEdition
     {
         public override void ActivateAbility()
         {
-            HostShip.OnGenerateDiceModifications += AddProtonTorpedoesDiceMofification;
+            HostShip.OnGenerateDiceModifications += AddProtonTorpedoesDiceModification;
         }
 
         public override void DeactivateAbility()
@@ -56,10 +56,10 @@ namespace Abilities.SecondEdition
         private void DeactivateAbilityPlanned(GenericShip ship)
         {
             HostShip.OnCombatDeactivation -= DeactivateAbilityPlanned;
-            HostShip.OnGenerateDiceModifications -= AddProtonTorpedoesDiceMofification;
+            HostShip.OnGenerateDiceModifications -= AddProtonTorpedoesDiceModification;
         }
 
-        protected virtual void AddProtonTorpedoesDiceMofification(GenericShip host)
+        protected virtual void AddProtonTorpedoesDiceModification(GenericShip host)
         {
             ProtonTorpedoesDiceModificationSE action = new ProtonTorpedoesDiceModificationSE()
             {


### PR DESCRIPTION
Copied in the LSL pilots from Legacy and added all the bits we have that already exist.

Added Top Cover, True Grit, Automated Loaders.

Automated Loaders seems to work fine, but it would be neat if it could check whether there is anything to reload before asking the question.
True Grit assigns the Strain, removes the requested token but then locks up and I can't see why.
Top Cover needs an extra condition for when a device has already been dropped/launched, but I'm not sure how to do that (do we already have something that does that?)