### PR TITLE
Fix malice

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -13,12 +13,12 @@ namespace Ship
 {
     public partial class GenericShip : ITargetLockable
     {
-        private     List<GenericAction> AvailableActionsList        = new List<GenericAction>();
-        private     List<GenericAction> AvailableFreeActionsList    = new List<GenericAction>();
-        private     List<GenericAction> AlreadyExecutedActions      = new List<GenericAction>();
+        private List<GenericAction> AvailableActionsList = new List<GenericAction>();
+        private List<GenericAction> AvailableFreeActionsList = new List<GenericAction>();
+        private List<GenericAction> AlreadyExecutedActions = new List<GenericAction>();
 
-        private     List<GenericAction> AvailableDiceModifications  = new List<GenericAction>();
-        private     List<GenericAction> AlreadUsedDiceModifications = new List<GenericAction>();
+        private List<GenericAction> AvailableDiceModifications = new List<GenericAction>();
+        private List<GenericAction> AlreadyUsedDiceModifications = new List<GenericAction>();
 
         public List<GenericAction> PlannedLinkedActions;
 
@@ -73,7 +73,7 @@ namespace Ship
         public static event EventHandlerShipTargetLockable OnTargetLockIsAcquiredGlobal;
 
         public event EventHandlerShip OnCoordinateTargetIsSelected;
-        public event EventHandlerShip OnJamTargetIsSelected;        
+        public event EventHandlerShip OnJamTargetIsSelected;
 
         public event EventHandlerShip OnRerollIsConfirmed;
 
@@ -146,7 +146,7 @@ namespace Ship
 
             GenerateAvailableActionsList();
 
-            foreach(GenericAction action in AvailableActionsList)
+            foreach (GenericAction action in AvailableActionsList)
             {
                 redActions.Add(GetActionAsRed(action));
             }
@@ -291,12 +291,14 @@ namespace Ship
                     Name = "Free action",
                     TriggerOwner = this.Owner.PlayerNo,
                     TriggerType = TriggerTypes.OnFreeAction,
-                    EventHandler = delegate {
+                    EventHandler = delegate
+                    {
                         FreeActionDecisonSubPhase newSubPhase = (FreeActionDecisonSubPhase)Phases.StartTemporarySubPhaseNew
                         (
                             "Free action decision",
                             typeof(FreeActionDecisonSubPhase),
-                            (Action)delegate {
+                            (Action)delegate
+                            {
                                 var phase = Phases.CurrentSubPhase as FreeActionDecisonSubPhase;
                                 if (phase != null && phase.ActionWasPerformed)
                                 {
@@ -535,24 +537,24 @@ namespace Ship
 
         public void AddAlreadyUsedDiceModification(GenericAction action)
         {
-            if (!action.CanBeUsedFewTimes) AlreadUsedDiceModifications.Add(action);
+            if (!action.CanBeUsedFewTimes) AlreadyUsedDiceModifications.Add(action);
         }
 
         public void RemoveAlreadyUsedDiceModification(GenericAction action)
         {
-            AlreadUsedDiceModifications.RemoveAll(a => a.Name == action.Name);
+            AlreadyUsedDiceModifications.RemoveAll(a => a.Name == action.Name);
         }
 
         public void ClearAlreadyUsedDiceModifications()
         {
-            AlreadUsedDiceModifications = new List<GenericAction>();
+            AlreadyUsedDiceModifications = new List<GenericAction>();
         }
 
         private bool IsDiceModificationAlreadyUsed(GenericAction action)
         {
             bool result = false;
 
-            foreach (var alreadyUsedAction in AlreadUsedDiceModifications)
+            foreach (var alreadyUsedAction in AlreadyUsedDiceModifications)
             {
                 if (alreadyUsedAction.DiceModificationName == action.DiceModificationName)
                 {
@@ -633,7 +635,8 @@ namespace Ship
             AcquireTargetLockSubPhase selectTargetLockSubPhase = (AcquireTargetLockSubPhase)Phases.StartTemporarySubPhaseNew(
                 "Select target for Target Lock",
                 typeof(AcquireTargetLockSubPhase),
-                delegate {
+                delegate
+                {
                     UI.HideSkipButton();
                     Phases.FinishSubPhase(typeof(AcquireTargetLockSubPhase));
                     callback();
@@ -756,7 +759,7 @@ namespace Ship
             if (OnActionIsReadyToBeFailed != null) OnActionIsReadyToBeFailed(action, failReasons, ref isDefaultFailOverwritten);
 
             Triggers.ResolveTriggers(
-                TriggerTypes.OnActionIsReadyToBeFailed, 
+                TriggerTypes.OnActionIsReadyToBeFailed,
                 delegate
                 {
                     CallOnActionIsReallyFailed(action, isDefaultFailOverwritten, hasSecondChance);

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
@@ -71,12 +71,7 @@ namespace Abilities.SecondEdition
 
         private bool IsDiceModificationAvailable()
         {
-            bool result = true;
-
-            if (Combat.AttackStep != CombatStep.Attack) result = false;
-            if (HostShip.State.Force < 1) result = false;
-
-            return result;
+            return (Combat.AttackStep == CombatStep.Attack) && (HostShip.State.Force >= 1);
         }
 
         private void payForce(Action<bool> callback)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
@@ -47,7 +47,7 @@ namespace Abilities.SecondEdition
         {
             RemoveDiceModification();
 
-            GenericShip.OnFaceupCritCardReadyToBeDealtGlobal += CheckRecoverForce;
+            GenericShip.OnFaceupCritCardReadyToBeDealtGlobal -= CheckRecoverForce;
         }
 
         private void CheckRecoverForce(GenericShip ship, GenericDamageCard crit, EventArgs e)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
@@ -57,16 +57,8 @@ namespace Abilities.SecondEdition
                 && (Tools.IsSameShip(Combat.Defender, HostShip) || Tools.IsSameShip(Combat.Attacker, HostShip))
                 && Combat.CurrentCriticalHitCard.IsFaceup && Combat.CurrentCriticalHitCard.Type == CriticalCardType.Pilot)
             {
-                Triggers.RegisterTrigger
-                (
-                    new Trigger()
-                    {
-                        Name = "Recover Force",
-                        TriggerType = TriggerTypes.OnFaceupCritCardIsDealt,
-                        TriggerOwner = HostShip.Owner.PlayerNo,
-                        EventHandler = RecoverForce
-                    }
-                );
+                abilityUsed = false;
+                HostShip.State.RestoreForce(2);
             }
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
@@ -15,7 +15,7 @@ namespace UpgradesList.SecondEdition
                 UpgradeType.ForcePower,
                 cost: 4,
                 restriction: new TagRestriction(Content.Tags.DarkSide),
-                abilityType: typeof(Abilities.SecondEdition.MaliceAbility)       
+                abilityType: typeof(Abilities.SecondEdition.MaliceAbility)
             );
         }
     }
@@ -71,7 +71,7 @@ namespace Abilities.SecondEdition
 
         private bool IsDiceModificationAvailable()
         {
-            return (Combat.AttackStep == CombatStep.Attack) && (HostShip.State.Force >= 1);
+            return (Combat.AttackStep == CombatStep.Attack) && (HostShip.State.Force >= 1) && (Combat.Attacker == HostShip);
         }
 
         private void payForce(Action<bool> callback)
@@ -81,7 +81,8 @@ namespace Abilities.SecondEdition
                 HostShip.State.SpendForce
                 (
                     1,
-                    delegate {
+                    delegate
+                    {
                         abilityUsed = true;
                         callback(true);
                     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Malice.cs
@@ -54,7 +54,7 @@ namespace Abilities.SecondEdition
         {
             if (abilityUsed
                 && Combat.Defender != null
-                && (Tools.IsSameShip(Combat.Defender, HostShip) || Tools.IsSameShip(Combat.Attacker, HostShip))
+                && (Tools.IsSameShip(Combat.Attacker, HostShip))
                 && Combat.CurrentCriticalHitCard.IsFaceup && Combat.CurrentCriticalHitCard.Type == CriticalCardType.Pilot)
             {
                 abilityUsed = false;


### PR DESCRIPTION
Address #171 issues.

Don't add the CheckRecoverForce handler again in DeactivateAbility.
Only add the mod for the HostShip, don't check it for every ship.
Don't check whether the host ship is the defender in CheckRecoverForce, because huh?