### PR TITLE
Battle Over Endor Rebel A-Wing pilots

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/ArvelCrynydBoE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/ArvelCrynydBoE.cs
@@ -1,0 +1,108 @@
+﻿using Abilities.SecondEdition;
+using Actions;
+using ActionsList;
+using Arcs;
+using Content;
+using System;
+using System.Collections.Generic;
+using Upgrade;
+using UpgradesList.SecondEdition;
+
+namespace Ship
+{
+    namespace SecondEdition.RZ1AWing
+    {
+        public class ArvelCrynydBoE : RZ1AWing
+        {
+            public ArvelCrynydBoE() : base()
+            {
+                PilotInfo = new PilotCardInfo25(
+                    "Arvel Crynyd",
+                    "Battle Over Endor",
+                    Faction.Rebel,
+                    3,
+                    4,
+                    0,
+                    isLimited: true,
+                    abilityType: typeof(ArvelCrynydBattleOverEndorAbility),
+                    tags: new List<Tags>
+                    {
+                        Tags.AWing
+                    },
+                    extraUpgradeIcons: new List<UpgradeType> {
+                        UpgradeType.Talent,
+                        UpgradeType.Talent,
+                        UpgradeType.Missile,
+                        UpgradeType.Configuration
+                    },
+                    isStandardLayout: true
+                );
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/arvelcrynyd-battleoverendor.png";
+
+                PilotNameCanonical = "arvelcrynyd-battleoverendor";
+
+                ShipInfo.Shields++;
+                
+                ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(BarrelRollAction), typeof(FocusAction)));
+                ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(SlamAction)));
+
+                ShipInfo.ArcInfo.Arcs.RemoveAll(n => n.ArcType == ArcType.Front);
+                ShipInfo.ArcInfo.Arcs.Add(new ShipArcInfo(ArcType.SingleTurret, 2));
+                
+                MustHaveUpgrades.Add(typeof(VectoredCannonsRZ1));
+                MustHaveUpgrades.Add(typeof(HeroicSacrifice));
+                MustHaveUpgrades.Add(typeof(ItsATrap));
+                MustHaveUpgrades.Add(typeof(ProtonRockets));
+            }            
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class ArvelCrynydBattleOverEndorAbility : GenericAbility
+    {
+        //While defending, you may gain 1 strain token to change 1 focus result to a evade result.
+        public override void ActivateAbility()
+        {
+            AddDiceModification(
+                "Arvel Crynyd",
+                IsAvailable,
+                AiPriority,
+                DiceModificationType.Change,
+                1,
+                sidesCanBeSelected: new List<DieSide>() { DieSide.Focus },
+                sideCanBeChangedTo: DieSide.Success,
+                payAbilityCost: PayAbilityCost
+            );
+        }
+        private void PayAbilityCost(Action<bool> callback)
+        {
+            HostShip.Tokens.AssignToken(typeof(Tokens.StrainToken), () => callback(true));
+        }
+
+        public bool IsAvailable()
+        {
+            return Combat.AttackStep == CombatStep.Defence && Combat.CurrentDiceRoll.HasResult(DieSide.Focus);
+        }
+
+        private int AiPriority()
+        {
+            int result = 0;
+
+            if (Combat.DiceRollAttack.Successes > Combat.DiceRollDefence.Successes
+                && Combat.DiceRollDefence.Focuses > 0 && !HostShip.Tokens.HasGreenTokens)
+            {
+                result = 15;
+            }
+
+            return result;
+        }
+
+        public override void DeactivateAbility()
+        {
+            RemoveDiceModification();
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/ArvelCrynydBoE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/ArvelCrynydBoE.cs
@@ -1,7 +1,6 @@
 ﻿using Abilities.SecondEdition;
 using Actions;
 using ActionsList;
-using Arcs;
 using Content;
 using System;
 using System.Collections.Generic;
@@ -46,9 +45,6 @@ namespace Ship
                 
                 ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(BarrelRollAction), typeof(FocusAction)));
                 ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(SlamAction)));
-
-                ShipInfo.ArcInfo.Arcs.RemoveAll(n => n.ArcType == ArcType.Front);
-                ShipInfo.ArcInfo.Arcs.Add(new ShipArcInfo(ArcType.SingleTurret, 2));
                 
                 MustHaveUpgrades.Add(typeof(VectoredCannonsRZ1));
                 MustHaveUpgrades.Add(typeof(HeroicSacrifice));

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/ArvelCrynydBoE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/ArvelCrynydBoE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bbd846e93facf16498ba59ef1c8cfb97

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/GemmerSojanBoE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/GemmerSojanBoE.cs
@@ -1,0 +1,102 @@
+﻿using Abilities.SecondEdition;
+using Content;
+using System;
+using System.Collections.Generic;
+using Tokens;
+using Upgrade;
+using UpgradesList.SecondEdition;
+
+namespace Ship
+{
+    namespace SecondEdition.RZ1AWing
+    {
+        public class GemmerSojanBoELSL : RZ1AWing
+        {
+            public GemmerSojanBoELSL() : base()
+            {
+                PilotInfo = new PilotCardInfo25(
+                    "Gemmer Sojan",
+                    "Battle Over Endor",
+                    Faction.Rebel,
+                    2,
+                    4,
+                    loadoutValue: 0,
+                    isLimited: true,
+                    abilityType: typeof(GemmerSojanBattleOverEndorAbility),
+                    tags: new List<Tags>
+                    {
+                        Tags.AWing
+                    },
+                    extraUpgradeIcons: new List<UpgradeType> {
+                        UpgradeType.Talent, 
+                        UpgradeType.Cannon,
+                        UpgradeType.Modification,
+                        UpgradeType.Modification,
+                        UpgradeType.Configuration
+                    },
+                    isStandardLayout: true
+                );
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/gemmersojan-battleoverendor.png";
+
+                PilotNameCanonical = "gemmersojan-battleoverendor";
+
+                MustHaveUpgrades.Add(typeof(VectoredCannonsRZ1));
+                MustHaveUpgrades.Add(typeof(ItsATrap));
+                MustHaveUpgrades.Add(typeof(PrecisionTunedCannons));
+                MustHaveUpgrades.Add(typeof(ChaffParticlesBoE));
+                MustHaveUpgrades.Add(typeof(TargetAssistAlgorithm));
+            }            
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class GemmerSojanBattleOverEndorAbility : GenericAbility
+    {
+        //While defending, you may gain 1 strain token to change up to 2 of your blank results to focus results.
+        public override void ActivateAbility()
+        {
+            AddDiceModification(
+                "Gemmer Sojan",
+                IsAvailable,
+                AiPriority,
+                DiceModificationType.Change,
+                2,
+                sidesCanBeSelected: new List<DieSide>() { DieSide.Blank },
+                sideCanBeChangedTo: DieSide.Focus,
+                payAbilityCost: PayAbilityCost
+            );
+        }
+        private void PayAbilityCost(Action<bool> callback)
+        {
+            HostShip.Tokens.AssignToken(typeof(Tokens.StrainToken), () => callback(true));
+        }
+
+        public bool IsAvailable()
+        {
+            return Combat.AttackStep == CombatStep.Defence && Combat.CurrentDiceRoll.HasResult(DieSide.Blank);
+        }
+
+        private int AiPriority()
+        {
+            int result = 0;
+
+            if (Combat.DiceRollAttack.Successes > Combat.DiceRollDefence.Successes
+                && Combat.DiceRollDefence.Blanks > 0 
+                && HostShip.Tokens.HasToken(typeof(FocusToken))
+                && Combat.DiceRollAttack.Successes > Combat.DiceRollDefence.Focuses + Combat.DiceRollDefence.Successes)
+            {
+                result = 55;
+            }
+
+            return result;
+        }
+
+        public override void DeactivateAbility()
+        {
+            RemoveDiceModification();
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/GemmerSojanBoE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/GemmerSojanBoE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 267bdfbae8695cc4a99c4abd4ad0b386

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/TychoCelchuBoE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/TychoCelchuBoE.cs
@@ -1,0 +1,119 @@
+﻿using Abilities.SecondEdition;
+using Actions;
+using ActionsList;
+using Content;
+using Ship;
+using System.Collections.Generic;
+using Tokens;
+using Upgrade;
+using UpgradesList.SecondEdition;
+
+namespace Ship
+{
+    namespace SecondEdition.RZ1AWing
+    {
+        public class TychoCelchuBoELSL : RZ1AWing
+        {
+            public TychoCelchuBoELSL() : base()
+            {
+                PilotInfo = new PilotCardInfo25(
+                    "Tycho Celchu",
+                    "Battle Over Endor",
+                    Faction.Rebel,
+                    5,
+                    4,
+                    loadoutValue: 0,
+                    isLimited: true,
+                    abilityType: typeof(TychoCelchuBattleOverEndorAbility),
+                    tags: new List<Tags>
+                    {
+                        Tags.AWing
+                    },
+                    extraUpgradeIcons: new List<UpgradeType> {
+                        UpgradeType.Talent, 
+                        UpgradeType.Talent,
+                        UpgradeType.Missile,
+                        UpgradeType.Modification,
+                        UpgradeType.Configuration
+                    },
+                    isStandardLayout: true
+                );
+
+                ImageUrl = "https://infinitearenas.com/xw2/images/quickbuilds/tychocelchu-battleoverendor.png";
+
+                PilotNameCanonical = "tychocelchu-battleoverendor-lsl";
+
+                ShipInfo.Shields++;
+
+                ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(FocusAction), typeof(ReloadAction)));
+                ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(BoostAction), typeof(EvadeAction)));
+
+                MustHaveUpgrades.Add(typeof(VectoredCannonsRZ1));
+                MustHaveUpgrades.Add(typeof(ItsATrap));
+                MustHaveUpgrades.Add(typeof(Juke));
+                MustHaveUpgrades.Add(typeof(ProtonRockets));
+                MustHaveUpgrades.Add(typeof(ChaffParticlesBoE));
+            }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class TychoCelchuBattleOverEndorAbility : GenericAbility
+    {
+        //While you are disarmed, you can still perform missile attacks. When you perform a missile attack while disarmed, roll a maximum of 4 dice.
+        GenericSpecialWeapon secondaryWeapon;
+
+        public override void ActivateAbility()
+        {
+            HostShip.OnWeaponsDisabledCheck += AllowMissileAttacks;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnWeaponsDisabledCheck -= AllowMissileAttacks;        
+        }
+
+        private void AllowMissileAttacks(ref bool result)
+        {
+            if (HostShip.Tokens.CountTokensByType(typeof(WeaponsDisabledToken)) != 1) return;
+
+            if (!IsMissileAttack()) return;
+
+            Messages.ShowInfo("The attack using " + secondaryWeapon.Name + " is allowed");
+
+            result = false;
+            
+            PrepareAttackDiceCap();
+        }
+
+        private bool IsMissileAttack()
+        {
+            secondaryWeapon = Combat.ChosenWeapon as GenericSpecialWeapon;
+
+            return (secondaryWeapon != null && secondaryWeapon.HasType(UpgradeType.Missile));
+        }
+
+        private void PrepareAttackDiceCap()
+        {
+            HostShip.AfterGotNumberOfAttackDiceCap += SetAttackDiceCap;
+            
+            HostShip.OnAttackFinish += RemoveAttackDiceCap;
+        }
+
+        private void SetAttackDiceCap(ref int count)
+        {
+            Messages.ShowInfo($"{HostShip.PilotInfo.PilotName} has a disarmed token, only 4 dice may be rolled when attacking with {secondaryWeapon.Name}");
+
+            if (count > 4) count = 4;
+        }
+
+        private void RemoveAttackDiceCap(GenericShip ship)
+        {
+            HostShip.AfterGotNumberOfAttackDiceCap -= SetAttackDiceCap;
+            
+            HostShip.OnAttackFinish -= RemoveAttackDiceCap;
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/TychoCelchuBoE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/RZ1AWing/TychoCelchuBoE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1786ba21cc46ed46adbb989de341b06

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/PrecisionTunedCannons.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/PrecisionTunedCannons.cs
@@ -1,0 +1,65 @@
+﻿using Abilities.SecondEdition;
+using Arcs;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class PrecisionTunedCannons : GenericSpecialWeapon
+    {
+        public PrecisionTunedCannons() : base()
+        {
+            IsHidden = true;
+
+            UpgradeInfo = new UpgradeCardInfo(
+                "Precision-Tuned Cannons",
+                UpgradeType.Cannon,
+                cost: 0,
+                weaponInfo: new SpecialWeaponInfo(
+                    attackValue: 2,
+                    minRange: 2,
+                    maxRange: 3,
+                    arc: ArcType.Front
+                ),
+                abilityType: typeof(PrecisionTunedCannonsAbility)
+            );
+
+            ImageUrl = "https://raw.githubusercontent.com/sampson-matt/FlyCasualLegacyCustomCards/refs/heads/main/BattleOverEndor/PrecisionTunedCannons.jpg";
+        } 
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class PrecisionTunedCannonsAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            AddDiceModification(
+                HostUpgrade.UpgradeInfo.Name,
+                IsDiceModificationAvailable,
+                GetDiceModificationAiPriority,
+                DiceModificationType.Add,
+                1,
+                sideCanBeChangedTo: DieSide.Focus
+            );
+        }
+
+        public override void DeactivateAbility()
+        {
+            RemoveDiceModification();
+        }
+
+        public bool IsDiceModificationAvailable()
+        {
+            return (Combat.AttackStep == CombatStep.Attack
+                && Combat.Attacker == HostShip
+                && Combat.ChosenWeapon is UpgradesList.SecondEdition.PrecisionTunedCannons
+                && Combat.Attacker.SectorsInfo.IsShipInSector(Combat.Defender, ArcType.Bullseye));
+        }
+
+        public int GetDiceModificationAiPriority()
+        {
+            return 110;
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/PrecisionTunedCannons.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/PrecisionTunedCannons.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c4b381bb1b2562468c44a7f80f60247

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
@@ -5,7 +5,6 @@ using Ship;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Unity.Android.Gradle.Manifest;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
@@ -79,7 +79,7 @@ namespace Abilities.SecondEdition
 
         private void CheckAbility(GenericShip ship, ref bool flag)
         {
-            flag = true;
+            flag = !HostShip.IsStressed;
         }
 
         private void RegisterAbility(GenericShip ship)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/VectoredCannonsRZ1.cs
@@ -5,6 +5,7 @@ using Ship;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Android.Gradle.Manifest;
 using Upgrade;
 
 namespace UpgradesList.SecondEdition
@@ -79,7 +80,8 @@ namespace Abilities.SecondEdition
 
         private void CheckAbility(GenericShip ship, ref bool flag)
         {
-            flag = !HostShip.IsStressed;
+            flag = ship.CanPerformFreeAction(new BoostAction() { HostShip = ship, Color = ActionColor.Red }) 
+                   || ship.CanPerformFreeAction(new RotateArcAction() { HostShip = ship, Color = ActionColor.Red });
         }
 
         private void RegisterAbility(GenericShip ship)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/ChaffParticlesBoE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/ChaffParticlesBoE.cs
@@ -66,7 +66,7 @@ namespace Abilities.SecondEdition
 
         private void UseAbility(object sender, EventArgs e)
         {
-            ChaffPartilcesAbilitySubphase subphase = Phases.StartTemporarySubPhaseNew<ChaffPartilcesAbilitySubphase>(
+            ChaffParticlesAbilitySubphase subphase = Phases.StartTemporarySubPhaseNew<ChaffParticlesAbilitySubphase>(
                 "Remove Token",
                 DecisionSubPhase.ConfirmDecision
             );
@@ -95,7 +95,7 @@ namespace Abilities.SecondEdition
             subphase.Start();
         }
 
-        private class ChaffPartilcesAbilitySubphase : DecisionSubPhase { }
+        private class ChaffParticlesAbilitySubphase : DecisionSubPhase { }
     }
 }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/ChaffParticlesBoE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/ChaffParticlesBoE.cs
@@ -1,0 +1,101 @@
+﻿using Abilities.SecondEdition;
+using SubPhases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tokens;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class ChaffParticlesBoE : GenericUpgrade
+    {
+        public ChaffParticlesBoE() : base()
+        {
+            IsHidden = true;
+
+            UpgradeInfo = new UpgradeCardInfo(
+                "Chaff Particles",
+                UpgradeType.Modification,
+                cost: 0,
+                abilityType: typeof(ChaffParticlesBoEAbility)
+            );
+
+            ImageUrl = "https://raw.githubusercontent.com/sampson-matt/FlyCasualLegacyCustomCards/refs/heads/main/BattleOverEndor/ChaffParticles.jpg";
+
+            NameCanonical = "chaffparticles-battleoverendor";
+        }        
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class ChaffParticlesBoEAbility : GenericAbility
+    {
+
+        public override void ActivateAbility()
+        {
+            HostShip.OnAfterNeutralizeResults += CheckAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnAfterNeutralizeResults -= CheckAbility;
+        }
+
+        private void CheckAbility()
+        {
+            if ((HostShip.Tokens.HasTokenByColor(TokenColors.Red) || HostShip.Tokens.HasTokenByColor(TokenColors.Orange)) && 
+                Combat.DiceRollDefence.Focuses > 0)
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnAfterNeutralizeResults, AskToRemove);
+            }
+        }
+
+        private void AskToRemove(object sender, EventArgs e)
+        {
+
+            AskToUseAbility(
+                HostUpgrade.UpgradeInfo.Name,
+                AlwaysUseByDefault,
+                UseAbility,
+                descriptionLong: "Do you want to spend 1 Focus result to remove 1 red or orange token?",
+                imageHolder: HostUpgrade
+            );
+        }
+
+        private void UseAbility(object sender, EventArgs e)
+        {
+            ChaffPartilcesAbilitySubphase subphase = Phases.StartTemporarySubPhaseNew<ChaffPartilcesAbilitySubphase>(
+                "Remove Token",
+                DecisionSubPhase.ConfirmDecision
+            );
+
+            subphase.Name = HostShip.PilotInfo.PilotName;
+            subphase.DescriptionShort = "Select a red or orange token to remove";
+            subphase.ImageSource = HostShip;
+
+            subphase.DecisionOwner = HostShip.Owner;
+            subphase.ShowSkipButton = true;            
+
+            List<GenericToken> tokensToRemove = HostShip.Tokens.GetTokensByColor(TokenColors.Red,TokenColors.Orange);
+
+            foreach (GenericToken token in tokensToRemove)
+            {
+                subphase.AddDecision(
+                    token.Name + ((token.GetType() == typeof(RedTargetLockToken)) ? " \"" + (token as RedTargetLockToken).Letter + "\"" : ""),
+                    delegate {
+                        tokensToRemove.Add(token);
+                        ActionsHolder.RemoveTokens(tokensToRemove, delegate {DecisionSubPhase.ConfirmDecision(); });
+                    }
+                );
+            }
+
+            subphase.DefaultDecisionName = subphase.GetDecisions().First().Name;
+            subphase.Start();
+        }
+
+        private class ChaffPartilcesAbilitySubphase : DecisionSubPhase { }
+    }
+}
+

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/ChaffParticlesBoE.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/ChaffParticlesBoE.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4796d416c363eb4f9657b3b65bb6528

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/TargetAssistAlgorithm.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/TargetAssistAlgorithm.cs
@@ -1,0 +1,67 @@
+﻿using Abilities.SecondEdition;
+using BoardTools;
+using Ship;
+using System;
+using System.Linq;
+using Tokens;
+using UnityEngine;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class TargetAssistAlgorithm : GenericUpgrade
+    {
+        public TargetAssistAlgorithm() : base()
+        {
+            IsHidden = true;
+
+            UpgradeInfo = new UpgradeCardInfo(
+                "Target-Assist Algorithm",
+                UpgradeType.Modification,
+                cost: 0,
+                abilityType: typeof(TargetAssistAlgorithmAbility)
+            );
+
+            ImageUrl = "https://raw.githubusercontent.com/sampson-matt/FlyCasualLegacyCustomCards/refs/heads/main/BattleOverEndor/TargetAssistAlgorithm.jpg";
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class TargetAssistAlgorithmAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnCombatActivation += RegisterAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnCombatActivation -= RegisterAbility;
+        }
+
+        private void RegisterAbility(GenericShip ship)
+        {
+            RegisterAbilityTrigger(TriggerTypes.OnCombatActivation, CheckConditions);
+        }
+
+        private void CheckConditions(object sender, EventArgs e)
+        {
+            if (!HostShip.Tokens.HasGreenTokens && Board.GetShipsInArcAtRange(HostShip, Arcs.ArcType.Front, new Vector2(0, 3),Team.Type.Enemy).Any())
+            {
+                Messages.ShowInfo("Target-Assist Algorithm: " + HostShip.PilotInfo.PilotName + " gains a Calculate token)");
+                HostShip.Tokens.AssignTokens(CreateCalculateToken, 1, Triggers.FinishTrigger);
+            }
+            else
+            {
+                Triggers.FinishTrigger();
+            }
+        }
+
+        private GenericToken CreateCalculateToken()
+        {
+            return new CalculateToken(HostShip);
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/TargetAssistAlgorithm.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/TargetAssistAlgorithm.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67afdb96872a38842a4426135e58840d

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/HeroicSacrifice.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/HeroicSacrifice.cs
@@ -1,0 +1,77 @@
+﻿using ActionsList;
+using Ship;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class HeroicSacrifice : GenericUpgrade
+    {
+        public HeroicSacrifice() : base()
+        {
+            UpgradeInfo = new UpgradeCardInfo
+            (
+                "Heroic Sacrifice",
+                UpgradeType.Talent,
+                cost: 0,
+                abilityType: typeof(Abilities.SecondEdition.HeroicSacrificeAbility)
+            );
+
+            IsHidden = true;
+
+            ImageUrl = "https://raw.githubusercontent.com/sampson-matt/FlyCasualLegacyCustomCards/refs/heads/main/BattleOverEndor/HeroicSacrifice.jpg";
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    //After you perform a SLAM action, roll 5 attack dice. Each large ship, huge ship, and scenario feature at range 0 suffers 1 damage for each hit / crit result, bypassing shields. Then this ship is destroyed.
+
+    //You can perform SLAM actions, even while stressed.
+    public class HeroicSacrificeAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.ActionBar.ActionsThatCanbePreformedwhileStressed.Add(typeof(SlamAction));
+            HostShip.OnActionIsPerformed += CheckAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.ActionBar.ActionsThatCanbePreformedwhileStressed.Remove(typeof(SlamAction));
+            HostShip.OnActionIsPerformed -= CheckAbility;
+        }
+
+        private void CheckAbility(GenericAction action)
+        {
+            if (action is SlamAction)
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, HeroicSacrificeDamage);
+            }
+        }
+
+        private void HeroicSacrificeDamage(object sender, EventArgs e)
+        {
+            Selection.ChangeActiveShip(HostShip);
+            PerformDiceCheck(
+                HostName,
+                DiceKind.Attack,
+                5,
+                DiceCheckFinished,
+                Triggers.FinishTrigger
+            );
+        }
+
+        private void DiceCheckFinished()
+        {
+            int damage = DiceCheckRoll.Successes + DiceCheckRoll.CriticalSuccesses;
+
+            List<GenericShip> bumpedLargeShips = HostShip.ShipsBumped.Where(s => s.ShipBase.Size == BaseSize.Large).ToList();
+
+            HostShip.DestroyShipForced(delegate { DealDamageToShips(bumpedLargeShips, damage, false, AbilityDiceCheck.ConfirmCheck); });
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/HeroicSacrifice.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/HeroicSacrifice.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b88a1f6f18849844e95630da0d49cab3

--- a/Assets/Scripts/Model/Phases/SubPhases/ActionSubphase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/ActionSubphase.cs
@@ -266,7 +266,7 @@ namespace SubPhases
                     Type actionType = kv.Key;
                     GenericAction linkedAction = kv.Value;
 
-                    if (action.GetType() == actionType)
+                    if (action.GetType() == actionType && (action.Color != Actions.ActionColor.Red || Selection.ThisShip.CallCheckCanPerformActionsWhileStressed()))
                     {
                         string linkedActionName = GetActionNameColored(kv.Value);
 


### PR DESCRIPTION
Added Gemmer Sojan, Tycho Celchu, and Arvel Crynyd "Battle over Endor" versions.

Added the following newly introduced upgrades:
Heroic Sacrifice (Talent)
Precision Tuned Cannons (Cannon)
Chaff Particles (Modification) - new version with BoE cards
Target-Assist Algorithm (Modification)

Added a check to original Vectored Cannons to only prompt user for action if they are able to take it.

Cleaned up Free Actions to not show the Linked Action when the ship isn't able to take it (due to the initial action being red, for example)