### PR TITLE
Dont allow grinq ability at range 0

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
@@ -106,7 +106,7 @@ namespace Abilities.SecondEdition
             if (HostShip.State.Force < 1)
                 return;
 
-            if (Combat.ShotInfo.Range > 1 || Combat.ShotInfo.Range == 0)
+            if (Combat.ShotInfo.Range != 1)
                 return;
 
             RegisterAbilityTrigger(TriggerTypes.OnAttackStart, delegate

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
@@ -86,7 +86,7 @@ namespace Abilities.SecondEdition
             if (HostShip.State.Force < 1)
                 return;
 
-            if (Combat.ShotInfo.Range == 2 || Combat.ShotInfo.Range == 3)
+            if (Combat.ShotInfo.Range < 2 || Combat.ShotInfo.Range > 3)
                 return;
 
             RegisterAbilityTrigger(TriggerTypes.OnAttackStart, delegate

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
@@ -103,10 +103,7 @@ namespace Abilities.SecondEdition
 
         private void RegisterInquisitorDefenseAbility()
         {
-            if (HostShip.State.Force < 1)
-                return;
-
-            if (Combat.ShotInfo.Range != 1)
+            if (HostShip.State.Force < 1 || Combat.ShotInfo.Range != 1)
                 return;
 
             RegisterAbilityTrigger(TriggerTypes.OnAttackStart, delegate

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
@@ -86,7 +86,7 @@ namespace Abilities.SecondEdition
             if (HostShip.State.Force < 1)
                 return;
 
-            if (Combat.ShotInfo.Range < 2)
+            if (Combat.ShotInfo.Range == 2 || Combat.ShotInfo.Range == 3)
                 return;
 
             RegisterAbilityTrigger(TriggerTypes.OnAttackStart, delegate

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
@@ -106,7 +106,7 @@ namespace Abilities.SecondEdition
             if (HostShip.State.Force < 1)
                 return;
 
-            if (Combat.ShotInfo.Range > 1)
+            if (Combat.ShotInfo.Range > 1 || Combat.ShotInfo.Range == 0)
                 return;
 
             RegisterAbilityTrigger(TriggerTypes.OnAttackStart, delegate

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEAdvancedV1/GrandInquisitor.cs
@@ -86,7 +86,7 @@ namespace Abilities.SecondEdition
             if (HostShip.State.Force < 1)
                 return;
 
-            if (Combat.ShotInfo.Range == 1)
+            if (Combat.ShotInfo.Range < 2)
                 return;
 
             RegisterAbilityTrigger(TriggerTypes.OnAttackStart, delegate


### PR DESCRIPTION
I guess the Grand Inquisitor code pre-dates being able to attack at range 0. This turns off the offensive ability where the attack is less than range 2 as opposed to just exactly equal to 1. And turns off the defensive ability if the range is zero.

Closes #239 