### PR TITLE
Revert Name/Shortname to SecondEdition

### DIFF
--- a/Assets/Scripts/Model/Editions/XWAEdition.cs
+++ b/Assets/Scripts/Model/Editions/XWAEdition.cs
@@ -2,8 +2,9 @@ namespace Editions
 {
     public class XWAEdition : SecondEdition
     {
-        public override string Name { get { return "XWA Edition"; } }
-        public override string NameShort { get { return "XWAEdition"; } }
+        // Return Second Edition to use same UI panels and pieces without duplicating entire chunks
+        //public override string Name { get { return "XWA Edition"; } }
+        //public override string NameShort { get { return "XWAEdition"; } }
         public override int MaxPoints { get { return 50; } }
 
         public XWAEdition() : base() { }


### PR DESCRIPTION
Changing name/shortname broke system panels and requires rewrites of most scripts to make work correctly. Reverting for now.