### PR TITLE
Corrected BTA-NR2-W Y-Wing

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/BTANR2WYWing.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/BTANR2WYWing.cs
@@ -4,6 +4,7 @@ using Ship.CardInfo;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Upgrade;
 using UpgradesList.SecondEdition;
 
 namespace Ship.SecondEdition.BTANR2WYWing
@@ -14,12 +15,13 @@ namespace Ship.SecondEdition.BTANR2WYWing
         {
             ShipCardInfo25 shipInfo = ShipInfo as ShipCardInfo25;
             shipInfo.ShipName = "BTA-NR2-W Y-wing";
+            shipInfo.UpgradeIcons.Upgrades.Add(UpgradeType.Configuration);
             shipInfo.LegalityInfo = new List<Legality>() { Legality.XWA };
-            shipInfo.FactionData = new FactionData ( new Dictionary<Faction, Type> { { Faction.Resistance, typeof(ZoriiBliss) }});
+            shipInfo.FactionData = new FactionData(new Dictionary<Faction, Type> { { Faction.Resistance, typeof(ZoriiBliss) } });
 
             ShipAbilities.Remove(ShipAbilities.First(n => n.GetType() == typeof(IntuitiveInterfaceAbility)));
 
-            MustHaveUpgrades.Add(typeof(WartimeLoadout));
+            DefaultUpgrades.Add(typeof(WartimeLoadout));
         }
     }
 }


### PR DESCRIPTION
Corrected BTA-NR2-W Y-Wing to include Configuration slot and default to Wartime Loadout.