### PR TITLE
Gar Saxon (Gunner) requirements check

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
@@ -1,4 +1,5 @@
-﻿using Ship;
+﻿using Arcs;
+using Ship;
 using SubPhases;
 using System;
 using Upgrade;
@@ -54,7 +55,7 @@ namespace Abilities.SecondEdition
 
         private void AskUseAbility(object sender, EventArgs e)
         {
-            
+
             AskToUseAbility(
                 HostUpgrade.UpgradeInfo.Name,
                 NeverUseByDefault,
@@ -81,7 +82,6 @@ namespace Abilities.SecondEdition
                 subphase.Start();
                 AllowRollAdditionalDie();
             }
-            
         }
 
         private void AllowRollAdditionalDie()
@@ -110,7 +110,6 @@ namespace Abilities.SecondEdition
                 && Combat.ChosenWeapon.WeaponType == WeaponTypes.PrimaryWeapon
                 && (Combat.ShotInfo.InArcByType(Arcs.ArcType.Rear) || Combat.ShotInfo.InArcByType(Arcs.ArcType.Front))
                 && (Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Red) || Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Orange));
-                
         }
 
         private void CanPerformTargetLock(ref bool result, GenericShip ship, ITargetLockable defender)
@@ -120,7 +119,8 @@ namespace Abilities.SecondEdition
 
             if (defender is GenericShip)
             {
-                result = BoardTools.Board.IsShipInArcByType(HostShip, defender as GenericShip, Arcs.ArcType.Front) || BoardTools.Board.IsShipInArcByType(HostShip, defender as GenericShip, Arcs.ArcType.Rear);
+                GenericShip target = defender as GenericShip;
+                result = HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
             }
 
             return;

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
@@ -108,7 +108,7 @@ namespace Abilities.SecondEdition
             return Combat.AttackStep == CombatStep.Attack
                 && Combat.Attacker == HostShip
                 && Combat.ChosenWeapon.WeaponType == WeaponTypes.PrimaryWeapon
-                && MeetsArcRequirements(Combat.Defender)
+                && (Combat.ShotInfo.InArcByType(Arcs.ArcType.Rear) || Combat.ShotInfo.InArcByType(Arcs.ArcType.Front))
                 && (Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Red) || Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Orange));
         }
 
@@ -119,15 +119,11 @@ namespace Abilities.SecondEdition
 
             if (defender is GenericShip)
             {
-                result = MeetsArcRequirements(defender as GenericShip);
+                GenericShip target = defender as GenericShip;
+                result = HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
             }
 
             return;
-        }
-
-        private bool MeetsArcRequirements(GenericShip target)
-        {
-            return HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
@@ -108,7 +108,7 @@ namespace Abilities.SecondEdition
             return Combat.AttackStep == CombatStep.Attack
                 && Combat.Attacker == HostShip
                 && Combat.ChosenWeapon.WeaponType == WeaponTypes.PrimaryWeapon
-                && (Combat.ShotInfo.InArcByType(Arcs.ArcType.Rear) || Combat.ShotInfo.InArcByType(Arcs.ArcType.Front))
+                && MeetsArcRequirements(Combat.Defender)
                 && (Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Red) || Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Orange));
         }
 
@@ -119,11 +119,15 @@ namespace Abilities.SecondEdition
 
             if (defender is GenericShip)
             {
-                GenericShip target = defender as GenericShip;
-                result = HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
+                result = MeetsArcRequirements(defender as GenericShip);
             }
 
             return;
+        }
+
+        private bool MeetsArcRequirements(GenericShip target)
+        {
+            return HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/GarSaxonGunner.cs
@@ -108,7 +108,7 @@ namespace Abilities.SecondEdition
             return Combat.AttackStep == CombatStep.Attack
                 && Combat.Attacker == HostShip
                 && Combat.ChosenWeapon.WeaponType == WeaponTypes.PrimaryWeapon
-                && (Combat.ShotInfo.InArcByType(Arcs.ArcType.Rear) || Combat.ShotInfo.InArcByType(Arcs.ArcType.Front))
+                && IsInFrontOrRearArc(Combat.Defender)
                 && (Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Red) || Combat.Defender.Tokens.HasTokenByColor(Tokens.TokenColors.Orange));
         }
 
@@ -119,11 +119,15 @@ namespace Abilities.SecondEdition
 
             if (defender is GenericShip)
             {
-                GenericShip target = defender as GenericShip;
-                result = HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
+                result = IsInFrontOrRearArc(defender as GenericShip);
             }
 
             return;
+        }
+
+        private bool IsInFrontOrRearArc(GenericShip target)
+        {
+            return HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Front).InArc || HostShip.SectorsInfo.GetSectorInfo(target, ArcType.Rear).InArc;
         }
     }
 }


### PR DESCRIPTION
Set GarSaxon to check sectors instead IsShipInArcByType which uses the primaryweapon and failes if the primary is a turret without a fixed Front or Rear.