### PR TITLE
Kalani ability fix

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/TacticalRelay/Kalani.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/TacticalRelay/Kalani.cs
@@ -33,8 +33,8 @@ namespace UpgradesList.SecondEdition
                 new Vector2(250, 1)
             );
 
-            
-        }        
+
+        }
     }
 }
 
@@ -99,13 +99,17 @@ namespace Abilities.SecondEdition
 
             HostUpgrade.State.SpendCharge();
             ActionsHolder.AcquireTargetLock(TargetShip, LastMovedShip, AssignStress, AssignStress);
-
-            Selection.ChangeActiveShip(LastMovedShip);
         }
 
         private void AssignStress()
         {
-            TargetShip.Tokens.AssignToken(typeof(StressToken), Triggers.FinishTrigger);
+            TargetShip.Tokens.AssignToken(typeof(StressToken), Cleanup);
+        }
+
+        private void Cleanup()
+        {
+            Selection.ChangeActiveShip(LastMovedShip);
+            Triggers.FinishTrigger();
         }
 
         private bool FilterTargets(GenericShip ship)


### PR DESCRIPTION
Moved ChangeActiveShip to before FinishTrigger, allowing the previously active ship to finish their select action phase as intended. Closes #167 