### PR TITLE
Fix Battle Over Endor B-Wing Pilot Action Bars

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/ASF01BWing/AdonFoxBattleOverEndor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/ASF01BWing/AdonFoxBattleOverEndor.cs
@@ -1,4 +1,6 @@
 ﻿using Abilities.SecondEdition;
+using Actions;
+using ActionsList;
 using Content;
 using System;
 using System.Collections.Generic;
@@ -43,6 +45,9 @@ namespace Ship.SecondEdition.ASF01BWing
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.PartingGift));
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.ProtonRockets));
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.ProtonBombs));
+
+            ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(ReloadAction), ActionColor.Red));
+            ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(BarrelRollAction), typeof(TargetLockAction)));
 
             ShipAbilities.Add(new GyroCockpit());
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/ASF01BWing/BraylenStrammBattleOverEndor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/ASF01BWing/BraylenStrammBattleOverEndor.cs
@@ -1,4 +1,6 @@
 using Abilities.SecondEdition;
+using Actions;
+using ActionsList;
 using BoardTools;
 using Content;
 using Ship;
@@ -50,6 +52,9 @@ namespace Ship.SecondEdition.ASF01BWing
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.HomingMissiles));
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.ProtonBombs));
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.DelayedFuses));
+
+            ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(ReloadAction), ActionColor.Red));
+            ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(BarrelRollAction), typeof(TargetLockAction)));
 
             ShipAbilities.Add(new GyroCockpit());
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/ASF01BWing/GinaMoonsongBattleOverEndor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Rebel/ASF01BWing/GinaMoonsongBattleOverEndor.cs
@@ -1,4 +1,6 @@
 ﻿using Abilities.SecondEdition;
+using Actions;
+using ActionsList;
 using BoardTools;
 using Content;
 using Ship;
@@ -52,6 +54,9 @@ namespace Ship.SecondEdition.ASF01BWing
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.Juke));
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.ProtonTorpedoes));
             MustHaveUpgrades.Add(typeof(UpgradesList.SecondEdition.IonBombs));
+
+            ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(ReloadAction), ActionColor.Red));
+            ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(BarrelRollAction), typeof(TargetLockAction)));
 
             ShipAbilities.Add(new GyroCockpit());
 


### PR DESCRIPTION
Correct Battle Over Endor B-Wing pilot action bars, adding red reload and linked Target Lock after Barrel Roll.