### PR TITLE
Ai not stressed from red actions

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/CustomizedAi/CustomizedAi.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/CustomizedAi/CustomizedAi.cs
@@ -1,10 +1,5 @@
 ﻿using ActionsList;
 using Arcs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Ship
 {
@@ -15,10 +10,12 @@ namespace Ship
         public delegate void EventHandlerShipWeaponInt(GenericShip targetShip, IShipWeapon weapon, ref int priority);
         public delegate void EventHandlerArcFacingInt(ArcFacing facing, ref int priority);
         public delegate void EventHandlerActionInt(GenericAction action, ref int priority);
+        public delegate void EventHandlerActionDbl(GenericAction action, ref double value);
 
         public event EventHandlerShipWeaponInt OnGetWeaponPriority;
         public event EventHandlerArcFacingInt OnGetRotateArcFacingPriority;
         public event EventHandlerActionInt OnGetActionPriority;
+        public event EventHandlerActionDbl OnRedActionPriorityModifier;
 
         public CustomizedAi(GenericShip host)
         {
@@ -38,6 +35,11 @@ namespace Ship
         public void CallGetActionPriority(GenericAction action, ref int priority)
         {
             OnGetActionPriority?.Invoke(action, ref priority);
+        }
+
+        public void CallGetRedActionPriorityModifier(GenericAction action, ref double value)
+        {
+            OnRedActionPriorityModifier?.Invoke(action, ref value);
         }
     }
 }

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -725,8 +725,6 @@ namespace Ship
             return color;
         }
 
-        // TODO: Added by sampson-matt, need to check difference against my CallOnCheckActionComplexity
-
         public ActionColor CallOnCheckActionColor(GenericAction action, ref ActionColor color)
         {
             OnCheckActionColor?.Invoke(action, ref color);

--- a/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
+++ b/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
@@ -108,16 +108,11 @@ namespace Players
                 // De-prioritize red actions unless overriden
                 if (action.IsRed)
                 {
-                    if (ship.IsStressed && !ship.CallCanPerformActionWhileStressed(action))
-                    {
-                        priority = int.MinValue;
-                    }
-                    else
-                    {
-                        double redActionPriorityModifier = 0.2;
-                        ship.Ai.CallGetRedActionPriorityModifier(action, ref redActionPriorityModifier);
-                        priority = (int)(priority * redActionPriorityModifier);
-                    }
+                    if (ship.IsStressed && !ship.CallCanPerformActionWhileStressed(action)) continue;
+
+                    double redActionPriorityModifier = 0.2;
+                    ship.Ai.CallGetRedActionPriorityModifier(action, ref redActionPriorityModifier);
+                    priority = (int)(priority * redActionPriorityModifier);
                 }
 
                 actionsPriority.Add(action, priority);

--- a/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
+++ b/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
@@ -95,25 +95,27 @@ namespace Players
 
             Dictionary<GenericAction, int> actionsPriority = new();
 
+            GenericShip ship = Selection.ThisShip;
+
             foreach (GenericAction action in availableActionsList)
             {
-                Selection.ThisShip.CallOnCheckActionComplexity(action, ref action.Color);
-                Selection.ThisShip.CallOnCheckActionColor(action, ref action.Color);
+                ship.CallOnCheckActionComplexity(action, ref action.Color);
+                ship.CallOnCheckActionColor(action, ref action.Color);
 
                 int priority = action.GetActionPriority();
-                Selection.ThisShip.Ai.CallGetActionPriority(action, ref priority);
+                ship.Ai.CallGetActionPriority(action, ref priority);
 
                 // De-prioritize red actions unless overriden
                 if (action.IsRed)
                 {
-                    if (Selection.ThisShip.IsStressed && !Selection.ThisShip.CallCanPerformActionWhileStressed(action))
+                    if (ship.IsStressed && !ship.CallCanPerformActionWhileStressed(action))
                     {
                         priority = int.MinValue;
                     }
                     else
                     {
                         double redActionPriorityModifier = 0.2;
-                        Selection.ThisShip.Ai.CallGetRedActionPriorityModifier(action, ref redActionPriorityModifier);
+                        ship.Ai.CallGetRedActionPriorityModifier(action, ref redActionPriorityModifier);
                         priority = (int)(priority * redActionPriorityModifier);
                     }
                 }

--- a/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
+++ b/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
@@ -39,7 +39,9 @@ namespace Players
 
         private void AssignManeuversRecursive()
         {
-            GenericShip shipWithoutManeuver = (!DebugManager.DebugStraightToCombat) ? AI.Aggressor.NavigationSubSystem.GetNextShipWithoutAssignedManeuver() : GetNextShipWithoutAssignedManeuver();
+            GenericShip shipWithoutManeuver = (!DebugManager.DebugStraightToCombat) ?
+                AI.Aggressor.NavigationSubSystem.GetNextShipWithoutAssignedManeuver() :
+                GetNextShipWithoutAssignedManeuver();
 
             if (shipWithoutManeuver != null)
             {
@@ -119,7 +121,8 @@ namespace Players
                 actionsPriority.Add(action, priority);
             }
 
-            actionsPriority = actionsPriority.OrderByDescending(n => n.Value).ToDictionary(n => n.Key, n => n.Value);
+            actionsPriority = actionsPriority.OrderByDescending(n => n.Value)
+                .ToDictionary(n => n.Key, n => n.Value);
 
             if (actionsPriority.Count > 0)
             {
@@ -157,7 +160,10 @@ namespace Players
         {
             Roster.HighlightPlayer(PlayerNo);
 
-            GenericShip nextShip = (!DebugManager.DebugStraightToCombat) ? AI.Aggressor.NavigationSubSystem.GetNextShipWithoutFinishedManeuver() : GetNextShipWithoutFinishedManeuver();
+            GenericShip nextShip = (!DebugManager.DebugStraightToCombat) ?
+                AI.Aggressor.NavigationSubSystem.GetNextShipWithoutFinishedManeuver() :
+                GetNextShipWithoutFinishedManeuver();
+
             if (nextShip != null)
             {
                 Selection.ChangeActiveShip("ShipId:" + nextShip.ShipId);

--- a/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
+++ b/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
@@ -1,5 +1,4 @@
-﻿using Actions;
-using ActionsList;
+﻿using ActionsList;
 using GameModes;
 using Ship;
 using SubPhases;
@@ -8,10 +7,8 @@ using System.Linq;
 
 namespace Players
 {
-
     public partial class AggressorAiPlayer : GenericAiPlayer
     {
-
         public AggressorAiPlayer() : base()
         {
             Name = "Aggressor AI";
@@ -89,15 +86,14 @@ namespace Players
             return AI.Aggressor.TargetingSubSystem.SelectTargetAndWeapon(Selection.ThisShip);
         }
 
-        protected override void PerformActionFromList(List<ActionsList.GenericAction> actionsList)
+        protected override void PerformActionFromList(List<GenericAction> actionsList)
         {
             bool isActionTaken = false;
 
-            List<ActionsList.GenericAction> availableActionsList = actionsList;
+            List<GenericAction> availableActionsList = actionsList;
 
-            Dictionary<ActionsList.GenericAction, int> actionsPriority = new Dictionary<ActionsList.GenericAction, int>();
+            Dictionary<GenericAction, int> actionsPriority = new();
 
-            foreach (var action in availableActionsList)
             foreach (GenericAction action in availableActionsList)
             {
                 Selection.ThisShip.CallOnCheckActionComplexity(action, ref action.Color);
@@ -118,7 +114,7 @@ namespace Players
                         double redActionPriorityModifier = 0.2;
                         Selection.ThisShip.Ai.CallGetRedActionPriorityModifier(action, ref redActionPriorityModifier);
                         priority = (int)(priority * redActionPriorityModifier);
-                    }                    
+                    }
                 }
 
                 actionsPriority.Add(action, priority);
@@ -128,14 +124,13 @@ namespace Players
 
             if (actionsPriority.Count > 0)
             {
-                KeyValuePair<ActionsList.GenericAction, int> prioritizedActions = actionsPriority.First();
+                KeyValuePair<GenericAction, int> prioritizedActions = actionsPriority.First();
 
                 if (prioritizedActions.Value > 0)
                 {
                     isActionTaken = true;
 
-                    //Actions.TakeActionStart(prioritizedActions.Key);
-                    JSONObject parameters = new JSONObject();
+                    JSONObject parameters = new();
                     parameters.AddField("name", prioritizedActions.Key.Name);
                     GameController.SendCommand(
                         GameCommandTypes.Decision,

--- a/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
+++ b/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
@@ -55,8 +55,7 @@ namespace Players
         private GenericShip GetNextShipWithoutAssignedManeuver()
         {
             return Roster.GetPlayer(Phases.CurrentSubPhase.RequiredPlayer).Ships.Values
-                .Where(n => n.AssignedManeuver == null && !n.State.IsIonized)
-                .FirstOrDefault();
+                .FirstOrDefault(n => n.AssignedManeuver == null && !n.State.IsIonized);
         }
 
         private void OpenDirectionsUiSilent()
@@ -173,8 +172,7 @@ namespace Players
         private static GenericShip GetNextShipWithoutFinishedManeuver()
         {
             return Roster.GetPlayer(Phases.CurrentSubPhase.RequiredPlayer).Ships.Values
-                .Where(n => !n.IsManeuverPerformed)
-                .FirstOrDefault();
+                .FirstOrDefault(n => !n.IsManeuverPerformed);
         }
     }
 }

--- a/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
+++ b/Assets/Scripts/Model/Players/AggressorAiPlayer.cs
@@ -1,11 +1,10 @@
-﻿using GameModes;
+﻿using Actions;
+using ActionsList;
+using GameModes;
 using Ship;
 using SubPhases;
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 namespace Players
 {
@@ -99,12 +98,28 @@ namespace Players
             Dictionary<ActionsList.GenericAction, int> actionsPriority = new Dictionary<ActionsList.GenericAction, int>();
 
             foreach (var action in availableActionsList)
+            foreach (GenericAction action in availableActionsList)
             {
+                Selection.ThisShip.CallOnCheckActionComplexity(action, ref action.Color);
+                Selection.ThisShip.CallOnCheckActionColor(action, ref action.Color);
+
                 int priority = action.GetActionPriority();
                 Selection.ThisShip.Ai.CallGetActionPriority(action, ref priority);
 
-                //Do not perform red action if this is not rotate arc action
-                if (action.IsRed && !(action is ActionsList.RotateArcAction)) priority = int.MinValue;
+                // De-prioritize red actions unless overriden
+                if (action.IsRed)
+                {
+                    if (Selection.ThisShip.IsStressed && !Selection.ThisShip.CallCanPerformActionWhileStressed(action))
+                    {
+                        priority = int.MinValue;
+                    }
+                    else
+                    {
+                        double redActionPriorityModifier = 0.2;
+                        Selection.ThisShip.Ai.CallGetRedActionPriorityModifier(action, ref redActionPriorityModifier);
+                        priority = (int)(priority * redActionPriorityModifier);
+                    }                    
+                }
 
                 actionsPriority.Add(action, priority);
             }

--- a/Assets/Scripts/Model/Rules/RulesList/ActionsRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/ActionsRule.cs
@@ -29,8 +29,7 @@ namespace RulesList
             color = Selection.ThisShip.CallOnCheckActionComplexity(action, ref color);
             Selection.ThisShip.CallOnCheckActionColor(action, ref color);
 
-            //AI perfroms red actions as white, because it is hard to calculate correct priority of red action
-            if (color == ActionColor.Red && !(Selection.ThisShip.Owner is Players.GenericAiPlayer))
+            if (color == ActionColor.Red)
             {
                 Triggers.RegisterTrigger(new Trigger()
                 {


### PR DESCRIPTION
Removed condition which limited stress from Red Actions to players only. The AI calc should take into account Red Actions instead of just not giving them stress as a crutch.