### PR TITLE
Global CallOnCombatCheckExtraAttack

### DIFF
--- a/Assets/Scripts/Model/Combat/Combat.cs
+++ b/Assets/Scripts/Model/Combat/Combat.cs
@@ -92,11 +92,11 @@ public static class Combat
 
             IsAttackAlreadyCalled = true;
 
-            JSONObject parameters = new JSONObject();
+            JSONObject parameters = new();
             parameters.AddField("id", attackerId.ToString());
             parameters.AddField("target", defenderId.ToString());
             parameters.AddField("weaponIsAlreadySelected", weaponIsAlreadySelected.ToString());
-            parameters.AddField("weapon", (chosenWeapon != null) ? chosenWeapon.Name : null);
+            parameters.AddField("weapon", chosenWeapon?.Name);
 
             return GameController.GenerateGameCommand(
                 GameCommandTypes.DeclareAttack,
@@ -123,10 +123,11 @@ public static class Combat
         Selection.ChangeAnotherShip("ShipId:" + defenderId);
 
         Action callback = Phases.CurrentSubPhase.CallBack;
-        var subphase = Phases.StartTemporarySubPhaseNew(
+        GenericSubPhase subphase = Phases.StartTemporarySubPhaseNew(
             "Extra Attack",
             typeof(AttackExecutionSubphase),
-            delegate {
+            delegate
+            {
                 Phases.FinishSubPhase(typeof(AttackExecutionSubphase));
                 callback();
             }
@@ -187,7 +188,7 @@ public static class Combat
 
     private static List<IShipWeapon> GetAvailbleAttackTypes(GenericShip thisShip, GenericShip anotherShip)
     {
-        List<IShipWeapon> availableWeapons = new List<IShipWeapon>();
+        List<IShipWeapon> availableWeapons = new();
 
         foreach (IShipWeapon shipWeapon in thisShip.GetAllWeapons())
         {
@@ -257,7 +258,7 @@ public static class Combat
 
     private static void PayAttackCost()
     {
-        if (PayExtraAttackCost == null) PayExtraAttackCost = callback => callback();
+        PayExtraAttackCost ??= callback => callback();
         ChosenWeapon.PayAttackCost(() => PayExtraAttackCost(StartAttack));
     }
 
@@ -276,7 +277,7 @@ public static class Combat
         if (DebugManager.DebugPhases) Debug.Log("Attack is started: " + Selection.ThisShip + " vs " + Selection.AnotherShip);
 
         Attacker = Selection.ThisShip;
-        Defender = Selection.AnotherShip;        
+        Defender = Selection.AnotherShip;
     }
 
     public static void CallAttackStart()
@@ -385,7 +386,7 @@ public static class Combat
 
     private static void ResolveCombatDamage()
     {
-        DamageSourceEventArgs damageArgs = new DamageSourceEventArgs()
+        DamageSourceEventArgs damageArgs = new()
         {
             Source = Attacker,
             DamageType = DamageTypes.ShipAttack
@@ -408,8 +409,7 @@ public static class Combat
 
     private static void CheckTwinAttack()
     {
-        GenericSpecialWeapon chosenSecondaryWeapon = ChosenWeapon as GenericSpecialWeapon;
-        if (chosenSecondaryWeapon != null && chosenSecondaryWeapon.WeaponInfo.TwinAttack && !Defender.IsDestroyed)
+        if (ChosenWeapon is GenericSpecialWeapon chosenSecondaryWeapon && chosenSecondaryWeapon.WeaponInfo.TwinAttack && !Defender.IsDestroyed)
         {
             if (attacksCounter == 0)
             {
@@ -474,14 +474,7 @@ public static class Combat
     {
         CleanupCombatData();
 
-        if (!Selection.ThisShip.IsCannotAttackSecondTime)
-        {
-            CheckExtraAttacks(FinishCombat);
-        }
-        else
-        {
-            FinishCombat();
-        }
+        CheckExtraAttacks(FinishCombat);
     }
 
     private static void FinishCombat()
@@ -491,7 +484,18 @@ public static class Combat
 
     private static void CheckExtraAttacks(Action callback)
     {
-        Selection.ThisShip.CallCombatCheckExtraAttack(callback);
+        GenericShip previousAttacker = Selection.ThisShip;
+
+        foreach (GenericShip ship in Roster.AllShips.Values)
+        {
+            if (!ship.IsCannotAttackSecondTime)
+            {
+                Selection.ThisShip = ship;
+                ship.CallCombatCheckExtraAttack();
+            }
+        }
+
+        Triggers.ResolveTriggers(TriggerTypes.OnCombatCheckExtraAttack, delegate { Selection.ThisShip = previousAttacker; callback(); });
     }
 
     private static void CleanupCombatData()
@@ -534,7 +538,7 @@ public static class Combat
         ExtraAttackFilter = extraAttackFilter;
         PayExtraAttackCost = payAttackCost;
 
-        SelectTargetForAttackSubPhase newAttackSubphase = (SelectTargetForAttackSubPhase) Phases.StartTemporarySubPhaseNew(
+        SelectTargetForAttackSubPhase newAttackSubphase = (SelectTargetForAttackSubPhase)Phases.StartTemporarySubPhaseNew(
             "Second attack",
             typeof(SelectTargetForAttackSubPhase),
             delegate
@@ -565,12 +569,12 @@ namespace SubPhases
 
             DescriptionShort = "Choose weapon for attack";
 
-            foreach (var weapon in allWeapons)
+            foreach (IShipWeapon weapon in allWeapons)
             {
                 if (weapon.IsShotAvailable(Selection.AnotherShip))
                 {
                     AddDecision(weapon.Name, delegate { PerformAttackWithWeapon(weapon); });
-                    AddTooltip(weapon.Name, (weapon as GenericSpecialWeapon != null) ? (weapon as GenericSpecialWeapon).ImageUrl : null );
+                    AddTooltip(weapon.Name, (weapon as GenericSpecialWeapon != null) ? (weapon as GenericSpecialWeapon).ImageUrl : null);
                 }
             }
 
@@ -605,7 +609,6 @@ namespace SubPhases
             Phases.FinishSubPhase(typeof(WeaponSelectionDecisionSubPhase));
             CallBack();
         }
-
     }
 
     public class SkippableWeaponSelectionDecisionSubPhase : WeaponSelectionDecisionSubPhase
@@ -645,6 +648,4 @@ namespace SubPhases
             Phases.CurrentSubPhase = Phases.CurrentSubPhase.PreviousSubPhase;
         }
     }
-
 }
-

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
@@ -24,11 +24,11 @@ namespace Ship
 
     public partial class GenericShip
     {
-        public List<PrimaryWeaponClass> PrimaryWeapons = new List<PrimaryWeaponClass>();
+        public List<PrimaryWeaponClass> PrimaryWeapons = new();
 
         public Damage Damage { get; protected set; }
 
-        public DiceRoll AssignedDamageDiceroll = new DiceRoll(DiceKind.Attack, 0, DiceRollCheckType.Virtual);
+        public DiceRoll AssignedDamageDiceroll = new(DiceKind.Attack, 0, DiceRollCheckType.Virtual);
 
         public bool IsCannotAttackSecondTime { get; set; }
         public bool CanAttackBumpedTargetAlways { get; set; }
@@ -415,11 +415,9 @@ namespace Ship
             Triggers.ResolveTriggers(TriggerTypes.OnShieldIsLost, callback);
         }
 
-        public void CallCombatCheckExtraAttack(Action callback)
+        public void CallCombatCheckExtraAttack()
         {
             OnCombatCheckExtraAttack?.Invoke(this);
-
-            Triggers.ResolveTriggers(TriggerTypes.OnCombatCheckExtraAttack, callback);
         }
 
         public void CallCombatActivation(Action callback)
@@ -809,7 +807,7 @@ namespace Ship
 
         public List<ManeuverTemplate> GetAvailableBombDropTemplates(GenericUpgrade upgrade)
         {
-            List<ManeuverTemplate> availableTemplates = new List<ManeuverTemplate>();
+            List<ManeuverTemplate> availableTemplates = new();
             availableTemplates.AddRange(upgrade.GetDefaultDropTemplates());
 
             OnGetAvailableBombDropTemplatesNoConditions?.Invoke(availableTemplates, upgrade);
@@ -823,7 +821,7 @@ namespace Ship
 
         public List<ManeuverTemplate> GetAvailableDeviceLaunchTemplates(GenericUpgrade upgrade)
         {
-            List<ManeuverTemplate> availableTemplates = new List<ManeuverTemplate>();
+            List<ManeuverTemplate> availableTemplates = new();
             availableTemplates.AddRange(upgrade.GetDefaultLaunchTemplates());
 
             OnGetAvailableBombLaunchTemplates?.Invoke(availableTemplates, upgrade);
@@ -840,7 +838,7 @@ namespace Ship
 
         public List<ManeuverTemplate> GetAvailableBarrelRollTemplates(GenericAction action)
         {
-            List<ManeuverTemplate> availableTemplates = new List<ManeuverTemplate>(ShipBase.BarrelRollTemplatesAvailable);
+            List<ManeuverTemplate> availableTemplates = new(ShipBase.BarrelRollTemplatesAvailable);
 
             OnGetAvailableBarrelRollTemplates?.Invoke(availableTemplates, action);
 
@@ -849,7 +847,7 @@ namespace Ship
 
         public List<ManeuverTemplate> GetAvailableDecloakBarrelRollTemplates()
         {
-            List<ManeuverTemplate> availableTemplates = new List<ManeuverTemplate>(ShipBase.DecloakBarrelRollTemplatesAvailable);
+            List<ManeuverTemplate> availableTemplates = new(ShipBase.DecloakBarrelRollTemplatesAvailable);
 
             OnGetAvailableDecloakTemplates?.Invoke(availableTemplates);
 
@@ -858,7 +856,7 @@ namespace Ship
 
         public List<BoostMove> GetAvailableBoostTemplates(GenericAction action)
         {
-            List<BoostMove> availableMoves = new List<BoostMove>
+            List<BoostMove> availableMoves = new()
             {
                 new BoostMove(ActionsHolder.BoostTemplates.Straight1),
                 new BoostMove(ActionsHolder.BoostTemplates.LeftBank1),
@@ -918,7 +916,7 @@ namespace Ship
 
         public List<IShipWeapon> GetAllWeapons()
         {
-            List<IShipWeapon> allWeapons = new List<IShipWeapon>();
+            List<IShipWeapon> allWeapons = new();
 
             foreach (PrimaryWeaponClass primaryWeapon in PrimaryWeapons)
             {
@@ -1070,8 +1068,7 @@ namespace Ship
 
         public void ShowAttackAnimationAndSound()
         {
-            GenericSpecialWeapon chosenSecondaryWeapon = Combat.ChosenWeapon as GenericSpecialWeapon;
-            if (chosenSecondaryWeapon == null || chosenSecondaryWeapon.HasType(UpgradeType.Cannon) || chosenSecondaryWeapon.HasType(UpgradeType.Illicit))
+            if (Combat.ChosenWeapon is not GenericSpecialWeapon chosenSecondaryWeapon || chosenSecondaryWeapon.HasType(UpgradeType.Cannon) || chosenSecondaryWeapon.HasType(UpgradeType.Illicit))
             { // Primary Weapons, Cannons, and Illicits (HotShotBlaster)
                 Sounds.PlayShots(SoundInfo.ShotsName, SoundInfo.ShotsCount);
                 AnimatePrimaryWeapon();

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/DecisionSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/DecisionSubPhase.cs
@@ -72,7 +72,7 @@ namespace SubPhases
 
         private GameObject DecisionPanel;
         private GameObject ButtonsHolder;
-        protected List<Decision> decisions = new List<Decision>();
+        protected List<Decision> decisions = new();
         public string DefaultDecisionName;
         public Players.GenericPlayer DecisionOwner;
         public bool ShowSkipButton;
@@ -83,7 +83,7 @@ namespace SubPhases
         public bool WasDecisionButtonPressed;
         public bool IsForced;
         public bool DecisionWasPreparedAndShown;
-        public Vector2 ImagesDamageCardSize = new Vector2(194, 300);
+        public Vector2 ImagesDamageCardSize = new(194, 300);
 
         public override void Start()
         {
@@ -121,6 +121,7 @@ namespace SubPhases
             {
                 newName = name + " #" + counter++;
             }
+
             decisions.Add(new Decision(newName, call, tooltip, count, color, isCentered));
 
             return newName;
@@ -134,6 +135,7 @@ namespace SubPhases
             {
                 newName = name + " #" + counter++;
             }
+
             decisions.Find(n => n.Name == newName).AddTooltip(imageUrl);
 
             return newName;
@@ -146,7 +148,7 @@ namespace SubPhases
 
         public static GameCommand GenerateDecisionCommand(string decisionName)
         {
-            JSONObject parameters = new JSONObject();
+            JSONObject parameters = new();
             decisionName = decisionName.Replace("\"", "\\\"");
             parameters.AddField("name", decisionName);
 
@@ -172,7 +174,7 @@ namespace SubPhases
                 if (decision == null)
                 {
                     string alldecisions = null;
-                    foreach (var singleDecision in (Phases.CurrentSubPhase as DecisionSubPhase).GetDecisions())
+                    foreach (Decision singleDecision in (Phases.CurrentSubPhase as DecisionSubPhase).GetDecisions())
                     {
                         alldecisions += singleDecision.Name + " ";
                     }
@@ -208,7 +210,7 @@ namespace SubPhases
                 int rowsUsed = 0;
                 int currentColumn = 1;
 
-                foreach (var decision in decisions)
+                foreach (Decision decision in decisions)
                 {
                     GameObject prefab = null;
 
@@ -280,8 +282,10 @@ namespace SubPhases
                             }
 
                             EventTrigger trigger = button.AddComponent<EventTrigger>();
-                            EventTrigger.Entry entry = new EventTrigger.Entry();
-                            entry.eventID = EventTriggerType.PointerClick;
+                            EventTrigger.Entry entry = new()
+                            {
+                                eventID = EventTriggerType.PointerClick
+                            };
                             entry.callback.AddListener(
                                 (data) => { DecisionButtonWasPressed(decision, button); }
                             );
@@ -376,10 +380,7 @@ namespace SubPhases
 
                 ButtonsHolder.transform.localPosition = new Vector2(-ButtonsHolder.GetComponent<RectTransform>().sizeDelta.x / 2, -185);
 
-                if (DecisionOwner == null)
-                {
-                    DecisionOwner = Roster.GetPlayer(Phases.CurrentPhasePlayer);
-                }
+                DecisionOwner ??= Roster.GetPlayer(Phases.CurrentPhasePlayer);
                 RequiredPlayer = DecisionOwner.PlayerNo;
                 Roster.HighlightPlayer(RequiredPlayer);
 
@@ -519,7 +520,5 @@ namespace SubPhases
                 }
             }
         }
-
     }
-
 }


### PR DESCRIPTION
While working on Stealth Gambit, I realized that it wasn't triggering correctly as the OnCombatCheckExtraAttack is only checked for the attacker and nobody else. I've modified Combat to cycle through every ship and process this now, then to call the trigger once at the end to fire everything off. This is working fine for Stealth Gambit now and appears fine for testing other bonus attacks. I believe this is also the problem with some of our other Issues and I'll try to tag those on this fix if it appears to resolve those as well.

Please test thoroughly and ensure other bonus attacks aren't firing when they shouldn't be. I don't see how they would, but never know. 

The only problem I see with this fix is that the UI doesn't update when we change ship selection, leaving the previous attacker and defender selected which can be confusing. I'll see what I can do about that.