### PR TITLE
Fix deathfire issues

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -38,7 +38,8 @@ namespace Ship
                         UpgradeType.Device,
                         UpgradeType.Device
                     },
-                    legality: new List<Legality> { Legality.StandardLegal, Legality.ExtendedLegal }
+                    legality: new List<Legality> { Legality.StandardLegal, Legality.ExtendedLegal },
+                    abilityText: "After you fully execute a speed 3-5 maneuver, if you have not dropped or launched a device this round, you may spend 2 charges to drop or launch a bomb using the 3-speed forward template."
                 );
                 PilotNameCanonical = "deathfire-swz98";
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -124,6 +124,8 @@ namespace Abilities.SecondEdition
             if (upgrade.UpgradeInfo.SubType != UpgradeSubType.Bomb) return;
             availableTemplates.Clear();
             availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed3, isBombTemplate: true));
+
+            ResetDelegates();
         }
 
         protected virtual void AddLaunchTemplate(List<ManeuverTemplate> availableTemplates, GenericUpgrade upgrade)
@@ -131,6 +133,14 @@ namespace Abilities.SecondEdition
             if (upgrade.UpgradeInfo.SubType != UpgradeSubType.Bomb) return;
             availableTemplates.Clear();
             availableTemplates.Add(new ManeuverTemplate(ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed3));
+
+            ResetDelegates();
+        }
+
+        private void ResetDelegates()
+        {
+            HostShip.OnGetAvailableBombDropTemplatesNoConditions -= AddDropTemplate;
+            HostShip.OnGetAvailableBombLaunchTemplates -= AddLaunchTemplate;
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -70,18 +70,18 @@ namespace Abilities.SecondEdition
     {
         public override void ActivateAbility()
         {
-            HostShip.OnMovementFinish += CheckAbility;
+            HostShip.OnMovementFinishSuccessfully += CheckAbility;
         }
 
         public override void DeactivateAbility()
         {
-            HostShip.OnMovementFinish -= CheckAbility;
+            HostShip.OnMovementFinishSuccessfully -= CheckAbility;
         }
 
         private void CheckAbility(GenericShip ship)
         {
             if (HostShip.AssignedManeuver.Speed is >= 3 and <= 5
-                && !HostShip.IsBumped && HostShip.State.Charges > 1
+                && HostShip.State.Charges > 1
                 && !HostShip.IsBombAlreadyDropped)
             {
                 RegisterAbilityTrigger(TriggerTypes.OnMovementFinish, AskUseAbility);

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIESaBomber/DeathfireTBE.cs
@@ -80,9 +80,6 @@ namespace Abilities.SecondEdition
 
         private void CheckAbility(GenericShip ship)
         {
-            //AI doesn't use ability
-            if (HostShip.Owner.UsesHotacAiRules) return;
-
             if (HostShip.AssignedManeuver.Speed is >= 3 and <= 5
                 && !HostShip.IsBumped && HostShip.State.Charges > 1
                 && !HostShip.IsBombAlreadyDropped)


### PR DESCRIPTION
Remove the check for an AI pilot.
Change to OnMovementCompletedSuccessfully and remove the IsBumped check
Add code to reset the templates after device drop/launch