### PR TITLE
Update zeb crew to 2.5 rules

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
@@ -1,6 +1,6 @@
 using Upgrade;
 using ActionsList;
-using BoardTools;
+using UnityEngine;
 
 namespace UpgradesList.SecondEdition
 {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
@@ -48,7 +48,6 @@ namespace Abilities.SecondEdition
         {
             allowed = allowed || 
                 action.GetType() == typeof(FocusAction) &&
-                Combat.ShotInfo.Weapon.WeaponType == WeaponTypes.PrimaryWeapon &&
                 (Combat.Attacker == HostShip || Combat.Defender == HostShip);
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
@@ -1,5 +1,6 @@
 using Upgrade;
 using ActionsList;
+using BoardTools;
 
 namespace UpgradesList.SecondEdition
 {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
@@ -1,6 +1,6 @@
-using Upgrade;
 using ActionsList;
 using UnityEngine;
+using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
@@ -1,7 +1,4 @@
-﻿using Ship;
 using Upgrade;
-using UnityEngine;
-using BoardTools;
 using ActionsList;
 
 namespace UpgradesList.SecondEdition
@@ -33,7 +30,6 @@ namespace Abilities.SecondEdition
 {
     public class ZebOrreliosCrewAbility : GenericAbility
     {
-
         public override void ActivateAbility()
         {
             Rules.DiceModification.OnAllowRangeZeroAttackModifications += AllowRange0FocusModification;
@@ -46,8 +42,8 @@ namespace Abilities.SecondEdition
 
         private void AllowRange0FocusModification(GenericAction action, ref bool allowed)
         {
-            allowed = allowed || 
-                action.GetType() == typeof(FocusAction) &&
+            allowed = allowed ||
+                action is FocusAction &&
                 (Combat.Attacker == HostShip || Combat.Defender == HostShip);
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ZebOrrelios.cs
@@ -2,6 +2,7 @@
 using Upgrade;
 using UnityEngine;
 using BoardTools;
+using ActionsList;
 
 namespace UpgradesList.SecondEdition
 {
@@ -35,20 +36,20 @@ namespace Abilities.SecondEdition
 
         public override void ActivateAbility()
         {
-            GenericShip.OnUpdateWeaponRangeGlobal += AllowRange0Primaries;
+            Rules.DiceModification.OnAllowRangeZeroAttackModifications += AllowRange0FocusModification;
         }
 
         public override void DeactivateAbility()
         {
-            GenericShip.OnUpdateWeaponRangeGlobal -= AllowRange0Primaries;
+            Rules.DiceModification.OnAllowRangeZeroAttackModifications -= AllowRange0FocusModification;
         }
 
-        private void AllowRange0Primaries(IShipWeapon weapon, ref int minRange, ref int maxRange, GenericShip target)
+        private void AllowRange0FocusModification(GenericAction action, ref bool allowed)
         {
-            if (weapon.WeaponType == WeaponTypes.PrimaryWeapon && (weapon.HostShip == HostShip || target == HostShip))
-            {
-                minRange = 0;
-            }
+            allowed = allowed || 
+                action.GetType() == typeof(FocusAction) &&
+                Combat.ShotInfo.Weapon.WeaponType == WeaponTypes.PrimaryWeapon &&
+                (Combat.Attacker == HostShip || Combat.Defender == HostShip);
         }
     }
 }


### PR DESCRIPTION
This was modelled off Bo-Katan (Separatists crew) and DiceModificationRule.IsAttackerRangeZeroDiceModification.
Is action.GetType() == typeof(FocusAction) the correct way to check for a focus token effect?