### PR TITLE
Where an upgrade is generic show the pilot name in the activation dialog

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
+++ b/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
@@ -107,7 +107,14 @@ namespace Abilities
             HostReal = hostUpgrade;
             HostShip = hostUpgrade.HostShip;
             HostUpgrade = hostUpgrade;
-            Name = Name ?? hostUpgrade.UpgradeInfo.Name + "'s ability";
+            if (HostUpgrade.UpgradeInfo.Limited == 0)
+            {
+                Name ??= $"{hostUpgrade.UpgradeInfo.Name}'s ({HostShip.PilotInfo.PilotName}) ability";
+            }
+            else
+            {
+                Name ??= $"{hostUpgrade.UpgradeInfo.Name}'s ability";
+            }
 
             ActivateAbilityForSquadBuilder();
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Cutthroat.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Cutthroat.cs
@@ -20,7 +20,7 @@ namespace UpgradesList.SecondEdition
                 abilityType: typeof(Abilities.SecondEdition.CutthroatAbility),
                 restriction: new FactionRestriction(Faction.Scum)
             );
-        }        
+        }
     }
 }
 
@@ -43,7 +43,7 @@ namespace Abilities.SecondEdition
             if (HostShip == ship) return;
             if (!Tools.IsAnotherFriendly(HostShip, ship)) return;
             if (!(ship.PilotInfo.IsLimited || ship.UpgradeBar.HasUpgradeInstalled(typeof(Cutthroat)))) return;
-            
+
             DistanceInfo distanceInfo = new DistanceInfo(HostShip, ship);
             if (distanceInfo.Range > 3) return;
 
@@ -52,7 +52,7 @@ namespace Abilities.SecondEdition
                 RegisterAbilityTrigger(
                     TriggerTypes.OnShipIsDestroyed,
                     AskWhatToDo,
-                    customTriggerName: $"{HostUpgrade.UpgradeInfo.Name} (ID: {HostShip.ShipId})"
+                    customTriggerName: $"{HostUpgrade.UpgradeInfo.Name} ({HostShip.PilotInfo.PilotName})"
                 );
             }
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Disciplined.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Disciplined.cs
@@ -19,9 +19,7 @@ namespace UpgradesList.SecondEdition
                 abilityType: typeof(Abilities.SecondEdition.DisciplinedAbility),
                 restriction: new FactionRestriction(Faction.Imperial)
             );
-
-            
-        }        
+        }
     }
 }
 
@@ -45,14 +43,14 @@ namespace Abilities.SecondEdition
         {
             if (!Tools.IsAnotherFriendly(HostShip, ship)) return;
             if (!ship.PilotInfo.IsLimited && !ship.UpgradeBar.HasUpgradeInstalled(typeof(Disciplined))) return;
-            
+
             DistanceInfo distanceInfo = new DistanceInfo(HostShip, ship);
             if (distanceInfo.Range > 3) return;
 
             RegisterAbilityTrigger(
                 TriggerTypes.OnShipIsDestroyed,
                 AskWhatToDo,
-                customTriggerName: $"{HostUpgrade.UpgradeInfo.Name} (ID: {HostShip.ShipId})"
+                customTriggerName: $"{HostUpgrade.UpgradeInfo.Name} ({HostShip.PilotInfo.PilotName})"
             );
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Hopeful.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Hopeful.cs
@@ -20,8 +20,8 @@ namespace UpgradesList.SecondEdition
                 restriction: new FactionRestriction(Faction.Rebel)
             );
 
-            
-        }        
+
+        }
     }
 }
 
@@ -45,14 +45,14 @@ namespace Abilities.SecondEdition
         {
             if (!Tools.IsAnotherFriendly(HostShip, ship)) return;
             if (!ship.PilotInfo.IsLimited && !ship.UpgradeBar.HasUpgradeInstalled(typeof(Hopeful))) return;
-            
+
             DistanceInfo distanceInfo = new DistanceInfo(HostShip, ship);
             if (distanceInfo.Range > 3) return;
 
             RegisterAbilityTrigger(
                 TriggerTypes.OnShipIsDestroyed,
                 AskWhatToDo,
-                customTriggerName: $"{HostUpgrade.UpgradeInfo.Name} (ID: {HostShip.ShipId})"
+                customTriggerName: $"{HostUpgrade.UpgradeInfo.Name} ({HostShip.PilotInfo.PilotName})"
             );
         }
 


### PR DESCRIPTION
While testing #433 I noticed that if you have multiple BB astros, when they activate in the System phase you get this:
<img width="1884" height="432" alt="image" src="https://github.com/user-attachments/assets/109703f5-36f6-4154-8afd-102da52a7976" />
and you can't tell which one is which.

This change means that when a generic upgrade activates, we show the pilot name each upgrade is attached to so players can make better choices
<img width="1825" height="434" alt="image" src="https://github.com/user-attachments/assets/580bcb0a-9e4b-4001-b491-82bd848b6926" />
