### PR TITLE
AI Tallon Roll fix

### DIFF
--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/TallonRollSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/TallonRollSubPhase.cs
@@ -199,6 +199,8 @@ public class TallonRollHelper
     {
         foreach (GameObject temporaryShipBase in TemporaryShipBases.Values.ToList())
         {
+            if (temporaryShipBase == null) continue;
+
             ObstaclesStayDetectorForced detector = temporaryShipBase.transform.Find("ShipBase").Find("ObstaclesStayDetector").gameObject.AddComponent<ObstaclesStayDetectorForced>();
 
             detector.ReCheckCollisionsStart();
@@ -222,7 +224,8 @@ public class TallonRollHelper
     public IEnumerator GetObstaclesLanded(int direction)
     {
         yield return CheckCollisions();
-        Ship.ObstaclesLanded = TemporaryShipBases[direction].GetComponentInChildren<ObstaclesStayDetectorForced>().OverlappedAsteroidsNow;
+        if (TemporaryShipBases.ContainsKey(direction))
+            Ship.ObstaclesLanded = TemporaryShipBases[direction].GetComponentInChildren<ObstaclesStayDetectorForced>().OverlappedAsteroidsNow;
     }
 
     public void DestroyTemporaryShipBases()


### PR DESCRIPTION
AI was crashing when performing tallon rolls due to helper templates being destroyed but still referenced.

Easiest way to test this is to change F:\Unity\FlyCasual\Assets\Scripts\Model\Ai\Aggressor\NavigationSubSystem\NavigationResult.cs to include the below at the top of the CalculatePriority method. This code will make Tallon Roll the top priority for the AI when deciding on which maneuver to perform.

`if(movement.Bearing == ManeuverBearing.TallonRoll)
{
    Priority = int.MaxValue;
    return;
}`

Then select any ship (i.e. TIE Silencer) that can perform a tallon roll.