### PR TITLE
Grand Moff Tarkin ability not triggering when lock acquired in System Phase

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/GrandMoffTarkin.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/GrandMoffTarkin.cs
@@ -22,17 +22,12 @@ namespace UpgradesList.SecondEdition
                 isLimited: true,
                 restrictions: new UpgradeCardRestrictions(
                     new FactionRestriction(Faction.Imperial),
-                    new ActionBarRestriction(typeof(TargetLockAction))
-                    ),
+                    new ActionBarRestriction(typeof(TargetLockAction))),
                 abilityType: typeof(Abilities.SecondEdition.GrandMoffTarkinAbility),
                 seImageNumber: 117,
                 charges: 2,
                 regensCharges: true,
-                legalityInfo: new List<Legality>
-                {
-                    Legality.StandardLegal,
-                    Legality.ExtendedLegal
-                }
+                legalityInfo: new List<Legality> { Legality.StandardLegal, Legality.ExtendedLegal }
             );
 
             Avatar = new AvatarInfo(
@@ -71,56 +66,65 @@ namespace Abilities.SecondEdition
 
         private void CheckForAbility(GenericShip ship, ref bool flag)
         {
-            if (HostUpgrade.State.Charges >= 2 && HostShip.Tokens.CountTokensByType<BlueTargetLockToken>() > 0) flag = true;
+            if (HostUpgrade.State.Charges >= 2) flag = true;
         }
 
         private void RegisterAbility(GenericShip ship)
         {
-            if (HostUpgrade.State.Charges >= 2 && HostShip.Tokens.CountTokensByType<BlueTargetLockToken>() > 0)
-            {
-                RegisterAbilityTrigger(TriggerTypes.OnSystemsAbilityActivation, AskToUseTarkinAbility);
-            }
+            RegisterAbilityTrigger(TriggerTypes.OnSystemsAbilityActivation, AskToUseTarkinAbility);
         }
 
         private void AskToUseTarkinAbility(object sender, EventArgs e)
         {
-            AskToUseAbility(
-                HostUpgrade.UpgradeInfo.Name,
-                AlwaysUseByDefault,
-                UseAbility,
-                dontUseAbility: delegate { DecisionSubPhase.ConfirmDecision(); },
-                descriptionLong: "Do you want to spend 2 Charges? (If you do, each friendly ship may acquire a target lock on a ship that you have locked)",
-                imageHolder: HostUpgrade
-            );
+            // Check locks here as other abilities may give a lock during system phase
+            if (HostShip.Tokens.CountTokensByType<BlueTargetLockToken>() > 0)
+            {
+                AskToUseAbility(
+                    HostUpgrade.UpgradeInfo.Name,
+                    AlwaysUseByDefault,
+                    UseAbility,
+                    dontUseAbility: delegate { DecisionSubPhase.ConfirmDecision(); },
+                    descriptionLong: "Do you want to spend 2 Charges? (If you do, each friendly ship may acquire a target lock on a ship that you have locked)",
+                    imageHolder: HostUpgrade
+                );
+            }
+            else
+            {
+                Messages.ShowErrorToHuman($"{HostShip.PilotInfo.PilotName} must have a lock to use {HostUpgrade.UpgradeInfo.Name}'s ability.");
+                Triggers.FinishTrigger();
+            }
         }
 
         protected void UseAbility(object sender, EventArgs e)
         {
-            HostUpgrade.State.SpendCharges(2);
-            var tarkinsLocks = HostShip.Tokens.GetTokens<BlueTargetLockToken>('*');
-            var targets = tarkinsLocks
+            List<BlueTargetLockToken> tarkinsLocks = HostShip.Tokens.GetTokens<BlueTargetLockToken>('*');
+
+            ITargetLockable[] targets = tarkinsLocks
                 .Where(t => t.OtherTargetLockTokenOwner is GenericShip)
                 .Select(t => t.OtherTargetLockTokenOwner)
                 .ToArray();
+
             // Limit the list of friendlies down to those that can actually lock these targets.
-            var friendlies = HostShip.Owner.Ships.Values
+            GenericShip[] friendlies = HostShip.Owner.Ships.Values
                 .Where(f => targets.Any(t =>
                 {
-                    var range = t.GetRangeToShip(f);
-                    return f.TargetLockMinRange <= range && f.TargetLockMaxRange >= range;
+                    int range = t.GetRangeToShip(f);
+                    return f != HostShip && f.TargetLockMinRange <= range && f.TargetLockMaxRange >= range;
                 }))
                 .ToArray();
+
             if (friendlies.Length == 0)
             {
-                Messages.ShowInfo(string.Format("No friendly ships are at Target Lock range of any of {0}'s targets", HostShip.PilotInfo.PilotName));
-
+                Messages.ShowInfo(string.Format($"No friendly ships are at Target Lock range of any of {HostShip.PilotInfo.PilotName}'s targets."));
             }
             else
             {
-                foreach (var friendly in friendlies)
+                HostUpgrade.State.SpendCharges(2);
+
+                foreach (GenericShip friendly in friendlies)
                 {
                     Triggers.RegisterTrigger(
-                        new Trigger()
+                        new()
                         {
                             Name = friendly.PilotInfo.PilotName + " (" + friendly.ShipId + ") can acquire " + HostShip.PilotInfo.PilotName + "'s Target Lock.",
                             TriggerOwner = HostShip.Owner.PlayerNo,
@@ -137,6 +141,7 @@ namespace Abilities.SecondEdition
                     );
                 }
             }
+
             Triggers.ResolveTriggers(TriggerTypes.OnAbilityDirect, DecisionSubPhase.ConfirmDecision);
         }
 
@@ -149,15 +154,17 @@ namespace Abilities.SecondEdition
 
         protected void AskToAcquireTarkinsLock(object sender, EventArgs e)
         {
-            var args = e as TarkinAbilityEventArgs;
-            var tarkinsShip = args.tarkinsShip;
-            var targets = args.tarkinsLocks;
-            var ship = args.tarkinsFriend;
-            var shipName = ship.PilotInfo.PilotName;
+            TarkinAbilityEventArgs args = e as TarkinAbilityEventArgs;
+            GenericShip tarkinsShip = args.tarkinsShip;
+            ITargetLockable[] targets = args.tarkinsLocks;
+            GenericShip ship = args.tarkinsFriend;
+            string shipName = ship.PilotInfo.PilotName;
+
             if (!ship.PilotInfo.IsLimited)
             {
                 shipName += " (" + ship.ShipId + ")";
             }
+
             SelectTargetForAbility(
                 () => LockTarget(ship, TargetShip),
                 t => targets.Contains(t),
@@ -176,7 +183,7 @@ namespace Abilities.SecondEdition
 
         protected int GetAiTargetPriority(GenericShip subject, GenericShip target)
         {
-            var isInArc = subject.ArcsInfo.Arcs
+            bool isInArc = subject.ArcsInfo.Arcs
                 .Select(arc => new BoardTools.ShotInfoArc(subject, target, arc))
                 .Any(arc => arc.InArc);
             return isInArc ? 1 : 0;


### PR DESCRIPTION
Moved targetlock checks into ability to allow target lock evaluation to be after other system events. Removed HostShip from ability as no need to get a lock on a ship you already have locked.

Closes #450 