### PR TITLE
Tweak the wording when generic upgrades activate

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
+++ b/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
@@ -109,7 +109,7 @@ namespace Abilities
             HostUpgrade = hostUpgrade;
             if (HostUpgrade.UpgradeInfo.Limited == 0)
             {
-                Name ??= $"{HostShip.PilotInfo.PilotName}'s {hostUpgrade.UpgradeInfo.Name} ability";
+                Name ??= $"{HostShip.PilotInfo.PilotName}: {hostUpgrade.UpgradeInfo.Name}";
             }
             else
             {

--- a/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
+++ b/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
@@ -109,7 +109,7 @@ namespace Abilities
             HostUpgrade = hostUpgrade;
             if (HostUpgrade.UpgradeInfo.Limited == 0)
             {
-                Name ??= $"{hostUpgrade.UpgradeInfo.Name}'s ({HostShip.PilotInfo.PilotName}) ability";
+                Name ??= $"{HostShip.PilotInfo.PilotName}'s {hostUpgrade.UpgradeInfo.Name} ability";
             }
             else
             {


### PR DESCRIPTION
Reword the activation dialog
<img width="860" height="273" alt="image" src="https://github.com/user-attachments/assets/6dc9d053-b555-4e3e-a946-3abd788fa50d" />
