### PR TITLE
Vennie - Evacuation of D'Qar

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs
@@ -88,7 +88,7 @@ namespace Abilities.SecondEdition
 
             public override bool IsDiceModificationAvailable()
             {
-                if (Combat.AttackStep == CombatStep.Defence)
+                if (Combat.AttackStep == CombatStep.Defence && Combat.CurrentDiceRoll.HasResult(DieSide.Focus))
                 {
                     foreach (GenericShip friendlyShip in Combat.Defender.Owner.Ships.Values)
                     {

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs
@@ -1,0 +1,110 @@
+using Abilities.SecondEdition;
+using Actions;
+using ActionsList;
+using Arcs;
+using BoardTools;
+using Content;
+using Ship;
+using System.Collections.Generic;
+using Upgrade;
+using UpgradesList.SecondEdition;
+
+namespace Ship.SecondEdition.Mg100StarFortress
+{
+    public class VennieEoD : Mg100StarFortress
+    {
+        public VennieEoD() : base()
+        {
+            PilotInfo = new PilotCardInfo25
+            (
+                "Vennie",
+                "Evacuation of D'Qar",
+                Faction.Resistance,
+                2,
+                17,
+                0,
+                isLimited: true,
+                abilityType: typeof(Abilities.SecondEdition.VennieAbilityEoD),
+                extraUpgradeIcons: new List<UpgradeType>()
+                {
+                    UpgradeType.Crew,
+                    UpgradeType.Gunner,
+                    UpgradeType.Gunner,
+                    UpgradeType.Device,
+                },
+                legality: new List<Legality>() { Legality.XWA },
+                isStandardLayout: true
+            );
+
+            ShipInfo.ActionIcons.AddLinkedAction(new LinkedActionInfo(typeof(RotateArcAction), typeof(FocusAction)));
+
+            ShipAbilities.Add(new ModularBombingMagazine());
+
+            MustHaveUpgrades.Add(typeof(PerceptiveCopilot));
+            MustHaveUpgrades.Add(typeof(ProtonBombs));
+            MustHaveUpgrades.Add(typeof(DedicatedGunners));
+
+
+            ModelInfo.SkinName = "Crimson";
+            PilotNameCanonical = "vennie-evacuationofdqar";
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class VennieAbilityEoD : GenericAbility
+    {
+
+        public override void ActivateAbility()
+        {
+            HostShip.OnGenerateDiceModifications += AddVennieAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnGenerateDiceModifications -= AddVennieAbility;
+        }
+
+        private void AddVennieAbility(GenericShip ship)
+        {
+            ship.AddAvailableDiceModificationOwn(new VennieEoDDiceModification()
+            {
+                ImageUrl = HostShip.ImageUrl
+            });
+        }
+
+        private class VennieEoDDiceModification : GenericAction
+        {
+            public VennieEoDDiceModification()
+            {
+                Name = DiceModificationName = "Vennie";
+            }
+
+            public override void ActionEffect(System.Action callBack)
+            {
+                Combat.CurrentDiceRoll.ChangeOne(DieSide.Focus,DieSide.Success);
+                callBack();
+            }
+
+            public override bool IsDiceModificationAvailable()
+            {
+                if (Combat.AttackStep == CombatStep.Defence)
+                {
+                    foreach (GenericShip friendlyShip in Combat.Defender.Owner.Ships.Values)
+                    {
+                        ShotInfo shotInfo = new ShotInfo(friendlyShip, Combat.Attacker, friendlyShip.PrimaryWeapons);
+                        if (shotInfo.InArcByType(ArcType.SingleTurret)) return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public override int GetDiceModificationPriority()
+            {
+                return 80;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs
@@ -44,7 +44,6 @@ namespace Ship.SecondEdition.Mg100StarFortress
             MustHaveUpgrades.Add(typeof(ProtonBombs));
             MustHaveUpgrades.Add(typeof(DedicatedGunners));
 
-
             ModelInfo.SkinName = "Crimson";
             PilotNameCanonical = "vennie-evacuationofdqar";
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Resistance/Mg100StarFortress/VennieEoD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c48a8a695a988fa44b9576796ce5354f

--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/Mg100StarFortress.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/Mg100StarFortress.cs
@@ -118,7 +118,8 @@ namespace Abilities.SecondEdition
                 imageHolder: HostShip,
                 decisions: new() {
                     { "Left", UseDeviceAbilityLeft },
-                    { "Right", UseDeviceAbilityRight }
+                    { "Right", UseDeviceAbilityRight },
+                    { "No", SkipUseAbility }
                 },
                 tooltips: new(),
                 defaultDecision: "No",
@@ -130,6 +131,11 @@ namespace Abilities.SecondEdition
         private void UseDeviceAbility()
         {
             HostShip.OnGetBombTemplateDirection += GetDeviceDirection;
+            Triggers.FinishTrigger();
+        }
+
+        private void SkipUseAbility(object sender, EventArgs e)
+        {
             Triggers.FinishTrigger();
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/Mg100StarFortress.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/Mg100StarFortress.cs
@@ -3,6 +3,7 @@ using ActionsList;
 using Arcs;
 using Movement;
 using Ship.CardInfo;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -84,6 +85,71 @@ namespace Ship
 
                 ShipIconLetter = 'Z';
             }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    // When you drop a device, you may set the template with its middle line aligned with the hashmark on the base in your left or right side.
+    public class ModularBombingMagazine : GenericAbility
+    {
+        Direction selectedDirection = Direction.Bottom;
+
+        public override void ActivateAbility()
+        {
+            HostShip.BeforeBombWillBeDropped += RegisterDeviceDropAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.BeforeBombWillBeDropped -= RegisterDeviceDropAbility;
+        }
+
+        private void RegisterDeviceDropAbility()
+        {
+            RegisterAbilityTrigger(TriggerTypes.BeforeBombWillBeDropped, AskToUseDeviceDropAbility);
+        }
+        private void AskToUseDeviceDropAbility(object sender, EventArgs e)
+        {
+            AskForDecision(
+                descriptionShort: "Modular Bombing Magazine",
+                descriptionLong: "Drop device using left or right side instead of rear guides?",
+                imageHolder: HostShip,
+                decisions: new() {
+                    { "Left", UseDeviceAbilityLeft },
+                    { "Right", UseDeviceAbilityRight }
+                },
+                tooltips: new(),
+                defaultDecision: "No",
+                callback: Triggers.FinishTrigger,
+                showSkipButton: true
+            );
+        }
+
+        private void UseDeviceAbility()
+        {
+            HostShip.OnGetBombTemplateDirection += GetDeviceDirection;
+            Triggers.FinishTrigger();
+        }
+
+        private void UseDeviceAbilityLeft(object sender, EventArgs e)
+        {
+            selectedDirection = Direction.Left;
+            UseDeviceAbility();
+        }
+
+        private void UseDeviceAbilityRight(object sender, EventArgs e)
+        {
+            selectedDirection = Direction.Right;
+            UseDeviceAbility();
+        }
+
+        private void GetDeviceDirection(ref Direction direction)
+        {
+            HostShip.OnGetBombTemplateDirection -= GetDeviceDirection;
+            direction = selectedDirection;
+            selectedDirection = Direction.Bottom;
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
@@ -32,6 +32,7 @@ namespace UpgradesList.SecondEdition
         }
     }
 }
+
 namespace Abilities.SecondEdition
 {
     // While you perform a primary attack, if the defender is in your turret arc, you may spend 1 focus token to roll 1 additional attack die.

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
@@ -1,0 +1,286 @@
+using ActionsList;
+using Arcs;
+using BoardTools;
+using Content;
+using Ship;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tokens;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class DedicatedGunners : GenericUpgrade
+    {
+        public DedicatedGunners() : base()
+        {
+            UpgradeInfo = new UpgradeCardInfo(
+                "Dedicated Gunners",
+                types: new List<UpgradeType>()
+                {
+                    UpgradeType.Gunner,
+                    UpgradeType.Gunner
+                },
+                cost: 0,
+                abilityType: typeof(Abilities.SecondEdition.DedicatedGunnersAbility),
+                legalityInfo: new() { Legality.XWA }
+            );
+
+            IsHidden = true;
+            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/vennie-evacuationofdqar.png";
+        }
+    }
+}
+namespace Abilities.SecondEdition
+{
+    // While you perform a primary attack, if the defender is in your turret arc, you may spend 1 focus token to roll 1 additional attack die.
+
+    // After you perform a primary attack, you may perform a bonus turret arc attack using a turret arc you did not already attack from this round.
+    public class DedicatedGunnersAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnAttackStartAsAttacker += CheckAddDieOption;
+            HostShip.OnAttackFinishAsAttacker += CheckBonusAttackAbility;
+            HostShip.Ai.OnGetWeaponPriority += ModifyWeaponPriority;
+            HostShip.Ai.OnGetActionPriority += ModifyRotateArcActionPriority;
+            HostShip.Ai.OnGetRotateArcFacingPriority += ModifyRotateArcFacingPriority;
+
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnAttackStartAsAttacker -= CheckAddDieOption;
+            HostShip.OnAttackFinishAsAttacker -= CheckBonusAttackAbility;
+            HostShip.Ai.OnGetWeaponPriority -= ModifyWeaponPriority;
+            HostShip.Ai.OnGetActionPriority -= ModifyRotateArcActionPriority;
+            HostShip.Ai.OnGetRotateArcFacingPriority -= ModifyRotateArcFacingPriority;
+
+        }
+
+        private void CheckAddDieOption()
+        {
+            RegisterAbilityTrigger(TriggerTypes.OnAttackStart, CheckTurretForAddDieOption);
+        }
+
+        private void CheckTurretForAddDieOption(object sender, EventArgs e)
+        {
+            if (Combat.ChosenWeapon.WeaponType == WeaponTypes.PrimaryWeapon
+                && HostShip.Tokens.HasToken<FocusToken>()
+                && HostShip.ArcsInfo.HasShipInTurretArc(Combat.Defender))
+            {
+                AskToUseAbility(
+                    HostUpgrade.UpgradeInfo.Name,
+                    AiSpendFocusForExtraDie,
+                    SpendFocusToAddDiceToRoll,
+                    descriptionLong: "Do you want to spend 1 Focus Token to roll 1 additional attack die?",
+                    imageHolder: HostShip,
+                    callback: Triggers.FinishTrigger
+                );
+            }
+            else
+            {
+                Triggers.FinishTrigger();
+            }
+        }
+
+        private bool AiSpendFocusForExtraDie()
+        {
+            return HostShip.Tokens.CountTokensByType<FocusToken>() >= 2;
+        }
+
+        private void SpendFocusToAddDiceToRoll(object sender, EventArgs e)
+        {
+            HostShip.Tokens.RemoveToken(typeof(FocusToken),AllowRollAdditionalDice);
+        }
+
+        private void AllowRollAdditionalDice()
+        {
+            Combat.Attacker.AfterGotNumberOfAttackDice += IncreaseByOne;
+            SubPhases.DecisionSubPhase.ConfirmDecision();
+        }
+
+        private void IncreaseByOne(ref int value)
+        {
+            value++;
+            Combat.Attacker.AfterGotNumberOfAttackDice -= IncreaseByOne;
+        }
+
+        // Copied From Veteran Turret Gunner
+        private void CheckBonusAttackAbility(GenericShip ship)
+        {
+            if (Combat.ShotInfo.Weapon.WeaponType != WeaponTypes.PrimaryWeapon) return;
+
+            if (HostShip.IsCannotAttackSecondTime) return;
+
+            bool availableArcsArePresent = HostShip.ArcsInfo.Arcs.Any(a => a.ArcType == ArcType.SingleTurret && !a.WasUsedForAttackThisRound);
+            if (availableArcsArePresent)
+            {
+                HostShip.OnCombatCheckExtraAttack += RegisterSecondAttackTrigger;
+            }
+            else
+            {
+                Messages.ShowError(HostUpgrade.UpgradeInfo.Name + " does not have any valid arcs to use");
+            }
+        }
+
+        private void RegisterSecondAttackTrigger(GenericShip ship)
+        {
+            HostShip.OnCombatCheckExtraAttack -= RegisterSecondAttackTrigger;
+
+            RegisterAbilityTrigger(TriggerTypes.OnCombatCheckExtraAttack, UseGunnerAbility);
+        }
+
+        private void UseGunnerAbility(object sender, System.EventArgs e)
+        {
+            if (!HostShip.IsCannotAttackSecondTime)
+            {
+                HostShip.IsCannotAttackSecondTime = true;
+
+                Combat.StartSelectAttackTarget(
+                    HostShip,
+                    FinishAdditionalAttack,
+                    IsUnusedTurretArcShot,
+                    HostUpgrade.UpgradeInfo.Name,
+                    "You may perform a bonus turret arc attack using another turret arc",
+                    HostUpgrade
+                );
+            }
+            else
+            {
+                Messages.ShowErrorToHuman(string.Format("{0} cannot attack an additional time", HostShip.PilotInfo.PilotName));
+                Triggers.FinishTrigger();
+            }
+        }
+
+        private void FinishAdditionalAttack()
+        {
+            // If attack is skipped, set this flag, otherwise regular attack can be performed second time
+            HostShip.IsAttackPerformed = true;
+
+            //if bonus attack was skipped, allow bonus attacks again
+            if (HostShip.IsAttackSkipped) HostShip.IsCannotAttackSecondTime = false;
+
+            Triggers.FinishTrigger();
+        }
+
+        private bool IsUnusedTurretArcShot(GenericShip defender, IShipWeapon weapon, bool isSilent)
+        {
+            ShotInfo shotInfo = new ShotInfo(HostShip, defender, weapon);
+            if (!shotInfo.ShotAvailableFromArcs.Any(a => a.ArcType == ArcType.SingleTurret && !a.WasUsedForAttackThisRound))
+            {
+                if (!isSilent) Messages.ShowError("Your attack must use a turret arc you have not already attacked from this round");
+                return false;
+            }
+
+            if (!weapon.WeaponInfo.ArcRestrictions.Contains(ArcType.SingleTurret))
+            {
+                if (!isSilent) Messages.ShowError("Your attack must use a turret arc");
+                return false;
+            }
+
+            return true;
+        }
+
+        // Ai (Agressor)
+        private void ModifyWeaponPriority(GenericShip targetShip, IShipWeapon weapon, ref int priority)
+        {
+            //If this is first attack, and ship can trigger VTG - priorize primary non-turret weapon
+            if
+            (
+                !HostShip.IsAttackPerformed
+                && weapon.WeaponType == WeaponTypes.PrimaryWeapon
+                && !weapon.WeaponInfo.ArcRestrictions.Contains(ArcType.SingleTurret)
+                && CanAttackTargetWithPrimaryWeapon(targetShip)
+                && CanAttackTargetWithTurret(targetShip)
+            )
+            {
+                priority += 2000;
+            }
+        }
+
+        private bool CanAttackTargetWithTurret(GenericShip targetShip)
+        {
+            foreach (GenericUpgrade turretUpgrade in Selection.ThisShip.UpgradeBar.GetSpecialWeaponsAll())
+            {
+                IShipWeapon turretWeapon = turretUpgrade as IShipWeapon;
+                if (turretWeapon.WeaponType == WeaponTypes.Turret)
+                {
+                    ShotInfo turretShot = new ShotInfo(HostShip, targetShip, turretWeapon);
+                    if (turretShot.IsShotAvailable)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool CanAttackTargetWithPrimaryWeapon(GenericShip targetShip)
+        {
+            //AI tries to check non-turret weapon first
+            IShipWeapon weapon = HostShip.PrimaryWeapons.FirstOrDefault(w => !w.WeaponInfo.ArcRestrictions.Contains(ArcType.SingleTurret));
+            if (weapon == null) weapon = HostShip.PrimaryWeapons.First();
+            ShotInfo primaryShot = new ShotInfo(HostShip, targetShip, weapon);
+            return primaryShot.IsShotAvailable;
+        }
+
+        private void ModifyRotateArcActionPriority(GenericAction action, ref int priority)
+        {
+            if (action is RotateArcAction)
+            {
+                // Rotate arc if ship has fixed arcs, has a target in it, but doesn't have a turret pointer in that sector
+                List<GenericArc> fixedArcs = HostShip.ArcsInfo.Arcs
+                                                            .Where(a => (!(a is ArcSingleTurret || a is OutOfArc)))
+                                                            .ToList();
+
+                if (fixedArcs.Count > 0 && HasTargetForWeapons(fixedArcs))
+                {
+                    List<ArcSingleTurret> singleTurretArcs = HostShip.ArcsInfo.Arcs
+                                                            .Where(a => a is ArcSingleTurret)
+                                                            .Select(a => a as ArcSingleTurret)
+                                                            .ToList();
+
+                    if (!singleTurretArcs.Any(sta => fixedArcs.Any(fa => fa.Facing == sta.Facing)))
+                    {
+                        priority += 100;
+                    }
+                }
+            }
+        }
+
+        private bool HasTargetForWeapons(List<GenericArc> arcs)
+        {
+            foreach (GenericArc arc in arcs)
+            {
+                foreach (GenericShip enemyShip in HostShip.Owner.EnemyShips.Values)
+                {
+                    ShotInfoArc shotInfoArc = new ShotInfoArc(HostShip, enemyShip, arc);
+                    if (shotInfoArc.IsShotAvailable) return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void ModifyRotateArcFacingPriority(ArcFacing facing, ref int priority)
+        {
+            if (facing == ArcFacing.Front && NoArcInFrontSector())
+            {
+                priority += (IsEnemyInFrontSector()) ? 100 : 5;
+            }
+        }
+
+        private bool NoArcInFrontSector()
+        {
+            return !HostShip.ArcsInfo.Arcs.Any(a => a.ArcType == ArcType.SingleTurret && a.Facing == ArcFacing.Front);
+        }
+
+        private bool IsEnemyInFrontSector()
+        {
+            return HostShip.Owner.EnemyShips.Any(e => HostShip.SectorsInfo.IsShipInSector(e.Value, ArcType.Front));
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
@@ -28,9 +28,7 @@ namespace UpgradesList.SecondEdition
             );
 
             IsHidden = true;
-            // todo: investigate why the correct imageUrl thows an error in sprite creation.
-            // ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/vennie-evacuationofdqar.png";
-            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/kyloren-evacuationofdqar.png";
+            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/vennie-evacuationofdqar.png";
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
@@ -30,13 +30,13 @@ namespace UpgradesList.SecondEdition
             IsHidden = true;
             // todo: investigate why the correct imageUrl thows an error in sprite creation.
             // ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/vennie-evacuationofdqar.png";
-            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/kyloren-evacuationofdqar.png";        }
+            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/kyloren-evacuationofdqar.png";
+        }
     }
 }
 namespace Abilities.SecondEdition
 {
     // While you perform a primary attack, if the defender is in your turret arc, you may spend 1 focus token to roll 1 additional attack die.
-
     // After you perform a primary attack, you may perform a bonus turret arc attack using a turret arc you did not already attack from this round.
     public class DedicatedGunnersAbility : GenericAbility
     {
@@ -47,7 +47,6 @@ namespace Abilities.SecondEdition
             HostShip.Ai.OnGetWeaponPriority += ModifyWeaponPriority;
             HostShip.Ai.OnGetActionPriority += ModifyRotateArcActionPriority;
             HostShip.Ai.OnGetRotateArcFacingPriority += ModifyRotateArcFacingPriority;
-
         }
 
         public override void DeactivateAbility()
@@ -57,7 +56,6 @@ namespace Abilities.SecondEdition
             HostShip.Ai.OnGetWeaponPriority -= ModifyWeaponPriority;
             HostShip.Ai.OnGetActionPriority -= ModifyRotateArcActionPriority;
             HostShip.Ai.OnGetRotateArcFacingPriority -= ModifyRotateArcFacingPriority;
-
         }
 
         private void CheckAddDieOption()

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs
@@ -28,8 +28,9 @@ namespace UpgradesList.SecondEdition
             );
 
             IsHidden = true;
-            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/vennie-evacuationofdqar.png";
-        }
+            // todo: investigate why the correct imageUrl thows an error in sprite creation.
+            // ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/vennie-evacuationofdqar.png";
+            ImageUrl = "https://infinitearenas.com/xw2xwa/images/pilots/kyloren-evacuationofdqar.png";        }
     }
 }
 namespace Abilities.SecondEdition
@@ -75,7 +76,7 @@ namespace Abilities.SecondEdition
                     AiSpendFocusForExtraDie,
                     SpendFocusToAddDiceToRoll,
                     descriptionLong: "Do you want to spend 1 Focus Token to roll 1 additional attack die?",
-                    imageHolder: HostShip,
+                    imageHolder: HostUpgrade,
                     callback: Triggers.FinishTrigger
                 );
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/DedicatedGunners.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cee5ad1b9e2c3784896f21fc59e37d0f


### PR DESCRIPTION
~~When using the correct card, dedicated gunners throws an error creating a sprite (both ability parts are effected). This did not happen with Kylo's card.~~  (Reloading VennieEoD in my image cache fixed this.)
The AI rotate action priority modifier code might need work.