### PR TITLE
Change SLAM to allow use in the ship's Activation Phase.

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/SlamAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/SlamAction.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using GameModes;
+﻿using Ship;
 using Tokens;
 
 namespace ActionsList
@@ -9,18 +6,23 @@ namespace ActionsList
 
     public class SlamAction : GenericAction
     {
-        private bool canBePerformedAsFreeAction = false;
-        public override bool CanBePerformedAsAFreeAction { get { return canBePerformedAsFreeAction; } }
-
         public SlamAction()
         {
             Name = DiceModificationName = "SLAM";
             ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/reference-cards/SlamAction.png";
         }
 
-        public SlamAction(bool canBePerformedAsFreeAction) : this()
+        public SlamAction(GenericShip hostShip)
         {
-            this.canBePerformedAsFreeAction = canBePerformedAsFreeAction;
+            Name = DiceModificationName = "SLAM";
+            ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/reference-cards/SlamAction.png";
+            HostShip = hostShip;
+        }
+
+        public override bool IsActionAvailable()
+        {
+            return Phases.CurrentPhase is MainPhases.ActivationPhase
+                && (Phases.CurrentPhase as MainPhases.ActivationPhase).ActivationShip == HostShip;
         }
 
         public override void ActionTake()

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEInterceptor/Sigma6BoY.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Empire/TIEInterceptor/Sigma6BoY.cs
@@ -96,7 +96,7 @@ namespace Abilities.SecondEdition
 
                 HostShip.AskPerformFreeAction
                 (
-                    new SlamAction(canBePerformedAsFreeAction: true) { HostShip = HostShip },
+                    new SlamAction(HostShip),
                     CleanUp,
                     HostShip.PilotInfo.PilotName,
                     "You may spend 1 charge to perform an SLAM action"

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/FO/TIEFoFighter/LinGaava.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/FO/TIEFoFighter/LinGaava.cs
@@ -162,7 +162,7 @@ namespace Conditions
 
         private void AddSlam(GenericShip ship)
         {
-            ship.AddAvailableAction(new SlamAction());
+            ship.AddAvailableAction(new SlamAction(ship));
         }
 
         private void CheckAbility()

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Republic/V19TorrentStarfighter/Slammer.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Republic/V19TorrentStarfighter/Slammer.cs
@@ -87,7 +87,7 @@ namespace Abilities.SecondEdition
         {
             HostShip.BeforeActionIsPerformed += RegisterSpendChargeTrigger;
             HostShip.AskPerformFreeAction(
-                new SlamAction(true) { CanBePerformedWhileStressed = true },
+                new SlamAction(HostShip),
                 CleanUp,
                 HostShip.PilotInfo.PilotName,
                 "After you fully execute a maneuver you may spend 1 Charge to perform a Slam action, even while stressed.",

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Illicit/CoaxiumHyperfuel.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Illicit/CoaxiumHyperfuel.cs
@@ -72,7 +72,7 @@ namespace Abilities.SecondEdition
         {
             HostShip.BeforeActionIsPerformed += RegisterSlamActionDamageTrigger;
             HostShip.AskPerformFreeAction(
-                new SlamAction(true),
+                new SlamAction(HostShip),
                 delegate
                 {
                     HostShip.BeforeActionIsPerformed -= RegisterSlamActionDamageTrigger;


### PR DESCRIPTION
The rules reference v1.4.6 states "A ship can perform a SLAM action only during its activation in the Activation Phase. Therefore a ship cannot perform a SLAM action if it is granted an action at any other time".


fixes #480