### PR TITLE
Bomb drop rework

### DIFF
--- a/Assets/Scripts/Model/Combat/Bombs.cs
+++ b/Assets/Scripts/Model/Combat/Bombs.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Upgrade;
+using UpgradesList.SecondEdition;
 
 namespace Bombs
 {
@@ -421,6 +422,7 @@ namespace Bombs
         public static List<GenericUpgrade> GetBombsToDrop(GenericShip ship, UpgradeSubType subType = UpgradeSubType.None, Type type = null)
         {
             return ship.UpgradeBar.GetUpgradesOnlyFaceup()
+                .Where(n => n is IDroppable)
                 .Where(n => typeof(GenericBomb).IsAssignableFrom(n.GetType()) || n.UpgradeInfo.SubType == subType)
                 .Where(n => !n.State.UsesCharges || n.State.Charges >= n.UpgradeInfo.ChargesCost)
                 .Where(n => subType == UpgradeSubType.None || n.UpgradeInfo.SubType == subType)

--- a/Assets/Scripts/Model/Content/Core/IDroppable.cs
+++ b/Assets/Scripts/Model/Content/Core/IDroppable.cs
@@ -1,0 +1,12 @@
+﻿using BoardTools;
+using System.Collections.Generic;
+
+namespace UpgradesList.SecondEdition
+{
+    public interface IDroppable
+    {
+        List<ManeuverTemplate> GetDefaultDropTemplates();
+
+        List<ManeuverTemplate> GetDefaultLaunchTemplates();
+    }
+}

--- a/Assets/Scripts/Model/Content/Core/IDroppable.cs
+++ b/Assets/Scripts/Model/Content/Core/IDroppable.cs
@@ -1,7 +1,7 @@
 ﻿using BoardTools;
 using System.Collections.Generic;
 
-namespace UpgradesList.SecondEdition
+namespace Upgrade
 {
     public interface IDroppable
     {

--- a/Assets/Scripts/Model/Content/Core/IDroppable.cs.meta
+++ b/Assets/Scripts/Model/Content/Core/IDroppable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4647b614a99b1cb4598bb1797ba1c294

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Tokens;
 using UnityEngine;
 using Upgrade;
+using UpgradesList.SecondEdition;
 
 namespace Ship
 {
@@ -817,7 +818,11 @@ namespace Ship
         public List<ManeuverTemplate> GetAvailableBombDropTemplates(GenericUpgrade upgrade)
         {
             List<ManeuverTemplate> availableTemplates = new();
-            availableTemplates.AddRange(upgrade.GetDefaultDropTemplates());
+
+            if(upgrade is IDroppable droppableUpgrade)
+            {
+                availableTemplates.AddRange(droppableUpgrade.GetDefaultDropTemplates());
+            }            
 
             OnGetAvailableBombDropTemplatesNoConditions?.Invoke(availableTemplates, upgrade);
             OnGetAvailableBombDropTemplatesTwoConditions?.Invoke(availableTemplates, upgrade);
@@ -831,7 +836,11 @@ namespace Ship
         public List<ManeuverTemplate> GetAvailableDeviceLaunchTemplates(GenericUpgrade upgrade)
         {
             List<ManeuverTemplate> availableTemplates = new();
-            availableTemplates.AddRange(upgrade.GetDefaultLaunchTemplates());
+
+            if(upgrade is IDroppable launchableUpgrade)
+            {
+                availableTemplates.AddRange(launchableUpgrade.GetDefaultLaunchTemplates());
+            }
 
             OnGetAvailableBombLaunchTemplates?.Invoke(availableTemplates, upgrade);
 

--- a/Assets/Scripts/Model/Content/Core/Ship/UpgradesBar/ShipUpgradeBar.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/UpgradesBar/ShipUpgradeBar.cs
@@ -125,7 +125,7 @@ namespace Upgrade
         public List<GenericUpgrade> GetUpgradesAll()
         {
             List<GenericUpgrade> result = new List<GenericUpgrade>();
-            result.AddRange(InstalledUpgradesAll_System.Where(n => !n.isPlaceholder));
+            result.AddRange(InstalledUpgradesAll_System.Where(n => !n.IsPlaceholder));
             return result;
         }
 

--- a/Assets/Scripts/Model/Content/Core/Upgrade/Bomb/GenericBomb.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/Bomb/GenericBomb.cs
@@ -1,14 +1,15 @@
-﻿using UnityEngine;
+﻿using BoardTools;
+using Bombs;
+using Movement;
 using Ship;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using Bombs;
+using UpgradesList.SecondEdition;
 
 namespace Upgrade
 {
 
-    abstract public class GenericBomb : GenericUpgrade
+    abstract public class GenericBomb : GenericUpgrade, IDroppable
     {
         public string bombPrefabPath;
 
@@ -19,14 +20,22 @@ namespace Upgrade
         public bool IsDiscardedAfterDropped;
         public int detonationRange = 0;
 
-        public List<GenericDeviceGameObject> CurrentBombObjects = new List<GenericDeviceGameObject>();
+        public List<GenericDeviceGameObject> CurrentBombObjects = new ();
 
         public delegate void SimpleEvent();
         public static SimpleEvent OnBombIsDetonated;
 
-        public GenericBomb() : base()
+        public virtual List<ManeuverTemplate> GetDefaultDropTemplates()
         {
+            return new List<ManeuverTemplate>()
+            {
+                new (ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
+            };
+        }
 
+        public virtual List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        {
+            return new ();
         }
 
         public override void AttachToShip(GenericShip host)
@@ -99,7 +108,7 @@ namespace Upgrade
             if (!ship.IgnoresBombDetonationEffect)
             {
                 ExplosionEffect(
-                    ship, 
+                    ship,
                     delegate { AfterBombEffect(ship, callBack); }
                 );
             }

--- a/Assets/Scripts/Model/Content/Core/Upgrade/EmptyUpgrade.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/EmptyUpgrade.cs
@@ -10,7 +10,7 @@ namespace UpgradesList
     {
         public EmptyUpgrade( ) : base()
         {
-            isPlaceholder = true;
+            IsPlaceholder = true;
         }
 
         public void SetUpgradeInfo(UpgradeType type, string Name, int Cost )

--- a/Assets/Scripts/Model/Content/Core/Upgrade/GenericUpgrade.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/GenericUpgrade.cs
@@ -71,7 +71,7 @@ namespace Upgrade
 
         public List<GenericAbility> UpgradeAbilities = new List<GenericAbility>();
 
-        public bool isPlaceholder = false;
+        public bool IsPlaceholder = false;
 
         public string NamePostfix;
 

--- a/Assets/Scripts/Model/Content/Core/Upgrade/GenericUpgrade.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/GenericUpgrade.cs
@@ -331,21 +331,5 @@ namespace Upgrade
             Slot.PreInstallUpgrade(newUpgrade, HostShip);
             Slot.TryInstallUpgrade(newUpgrade, HostShip);
         }
-
-        // Default templates to drop devices
-
-        public virtual List<ManeuverTemplate> GetDefaultDropTemplates()
-        {
-            return new List<ManeuverTemplate>()
-            {
-                new ManeuverTemplate(ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
-            };
-        }
-
-        public virtual List<ManeuverTemplate> GetDefaultLaunchTemplates()
-        {
-            return new List<ManeuverTemplate>();
-        }
     }
-
 }

--- a/Assets/Scripts/Model/Content/Core/Upgrade/GenericUpgrade.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/GenericUpgrade.cs
@@ -1,15 +1,11 @@
 ﻿using Abilities;
 using Mods;
+using Ship;
 using SquadBuilderNS;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using Ship;
-using Editions;
-using BoardTools;
-using Movement;
 
 namespace Upgrade
 {
@@ -19,11 +15,11 @@ namespace Upgrade
         public Vector2 AvatarOffset;
         public Vector2 AvatarSize;
 
-        public AvatarInfo(Faction faction, Vector2 offset, Vector2 size = default(Vector2))
+        public AvatarInfo(Faction faction, Vector2 offset, Vector2 size = default)
         {
             AvatarFaction = faction;
             AvatarOffset = offset;
-            AvatarSize = (size != default(Vector2)) ? size : new Vector2(100, 100);
+            AvatarSize = (size != default) ? size : new Vector2(100, 100);
         }
     }
 
@@ -69,7 +65,7 @@ namespace Upgrade
         public GenericShip HostShip { get; set; }
         public UpgradeSlot Slot { get; set; }
 
-        public List<GenericAbility> UpgradeAbilities = new List<GenericAbility>();
+        public List<GenericAbility> UpgradeAbilities = new();
 
         public bool IsPlaceholder = false;
 
@@ -132,7 +128,7 @@ namespace Upgrade
             {
                 List<UpgradeSlot> freeSlots = ship.UpgradeBar.GetFreeSlots(UpgradeInfo.UpgradeTypes);
 
-                foreach (var requiredSlotType in UpgradeInfo.UpgradeTypes)
+                foreach (UpgradeType requiredSlotType in UpgradeInfo.UpgradeTypes)
                 {
                     UpgradeSlot freeSlotByType = freeSlots.FirstOrDefault(n => n.Type == requiredSlotType);
                     if (freeSlotByType != null)
@@ -188,9 +184,12 @@ namespace Upgrade
          * @param type the type of upgrade to test.
          * @return true if this upgrade contains the specified type and false otherwise.
          */
-        public bool HasType(UpgradeType type){
-            for (int i = 0; i < UpgradeInfo.UpgradeTypes.Count; i++) {
-                if (UpgradeInfo.UpgradeTypes[i] == type) {
+        public bool HasType(UpgradeType type)
+        {
+            for (int i = 0; i < UpgradeInfo.UpgradeTypes.Count; i++)
+            {
+                if (UpgradeInfo.UpgradeTypes[i] == type)
+                {
                     return true;
                 }
             }
@@ -200,8 +199,10 @@ namespace Upgrade
         /**
          * Returns the type as a string.
          * @return the name of the type.
+         * TODO: Remove SalvagedAstromech from codebase, no longer an upgradetype
          */
-        public string getTypesAsString(){
+        public string getTypesAsString()
+        {
             string name = "";
             /*
             for (int i = 0; i < Types.Count; i++) {
@@ -221,12 +222,13 @@ namespace Upgrade
             }
             */
             UpgradeType type = UpgradeInfo.UpgradeTypes[0];
-            switch (type) {
+            switch (type)
+            {
                 case UpgradeType.SalvagedAstromech:
                     name += "Salvaged Astromech";
                     break;
                 default:
-                    name += type.ToString ();
+                    name += type.ToString();
                     break;
             }
             return name;
@@ -249,7 +251,7 @@ namespace Upgrade
 
         public void ActivateAbility()
         {
-            foreach (var ability in UpgradeAbilities)
+            foreach (GenericAbility ability in UpgradeAbilities)
             {
                 ability.InitializeForSquadBuilder(this);
                 ability.ActivateAbility();
@@ -258,7 +260,7 @@ namespace Upgrade
 
         public void DeactivateAbility()
         {
-            foreach (var ability in UpgradeAbilities)
+            foreach (GenericAbility ability in UpgradeAbilities)
             {
                 ability.DeactivateAbility();
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ClanWrenCommandos.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ClanWrenCommandos.cs
@@ -7,7 +7,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class ClanWrenCommandos : GenericUpgrade
+    public class ClanWrenCommandos : GenericUpgrade, IDroppable
     {
         public ClanWrenCommandos() : base()
         {
@@ -33,12 +33,17 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>()
             {
                 new (ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
             };
+        }
+
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        {
+            return new List<ManeuverTemplate>();
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/DeathWatchCommandos.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/DeathWatchCommandos.cs
@@ -7,7 +7,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class DeathWatchCommandos : GenericUpgrade
+    public class DeathWatchCommandos : GenericUpgrade, IDroppable
     {
         public DeathWatchCommandos() : base()
         {
@@ -33,12 +33,17 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>()
             {
                 new (ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
             };
+        }
+
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        {
+            return new List<ManeuverTemplate>();
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ImperialSuperCommandos.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ImperialSuperCommandos.cs
@@ -7,7 +7,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class ImperialSuperCommandos : GenericUpgrade
+    public class ImperialSuperCommandos : GenericUpgrade, IDroppable
     {
         public ImperialSuperCommandos() : base()
         {
@@ -33,12 +33,17 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>()
             {
                 new (ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
             };
+        }
+
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        {
+            return new List<ManeuverTemplate>();
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/MandalorianSuperCommandos.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/MandalorianSuperCommandos.cs
@@ -7,7 +7,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class MandalorianSuperCommandos : GenericUpgrade
+    public class MandalorianSuperCommandos : GenericUpgrade, IDroppable
     {
         public MandalorianSuperCommandos() : base()
         {
@@ -33,12 +33,17 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>()
             {
                 new (ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
             };
+        }
+
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        {
+            return new List<ManeuverTemplate>();
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/NiteOwlCommandos.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/NiteOwlCommandos.cs
@@ -7,7 +7,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class NiteOwlCommandos : GenericUpgrade
+    public class NiteOwlCommandos : GenericUpgrade, IDroppable
     {
         public NiteOwlCommandos() : base()
         {
@@ -33,12 +33,17 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>()
             {
                 new (ManeuverBearing.Straight, ManeuverDirection.Forward, ManeuverSpeed.Speed1, isBombTemplate: true)
             };
+        }
+
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        {
+            return new List<ManeuverTemplate>();
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Device/Drk1ProbeDroids.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Device/Drk1ProbeDroids.cs
@@ -8,7 +8,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class Drk1ProbeDroids : GenericUpgrade
+    public class Drk1ProbeDroids : GenericUpgrade, IDroppable
     {
         public Drk1ProbeDroids() : base()
         {
@@ -27,7 +27,7 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>()
             {
@@ -39,7 +39,7 @@ namespace UpgradesList.SecondEdition
             };
         }
 
-        public override List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
         {
             return new List<ManeuverTemplate>()
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Missile/DiscordMissiles.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Missile/DiscordMissiles.cs
@@ -9,7 +9,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class DiscordMissiles : GenericUpgrade
+    public class DiscordMissiles : GenericUpgrade, IDroppable
     {
         public DiscordMissiles() : base()
         {
@@ -28,12 +28,12 @@ namespace UpgradesList.SecondEdition
             );
         }
 
-        public override List<ManeuverTemplate> GetDefaultDropTemplates()
+        public List<ManeuverTemplate> GetDefaultDropTemplates()
         {
             return new List<ManeuverTemplate>();
         }
 
-        public override List<ManeuverTemplate> GetDefaultLaunchTemplates()
+        public List<ManeuverTemplate> GetDefaultLaunchTemplates()
         {
             return new List<ManeuverTemplate>()
             {


### PR DESCRIPTION
Moved droppable upgrade-specific methods to new interface, updated Bombs to check for interface when determining upgrades which are available for dropping. This removes checks for specific upgrade types or subtypes--functionality is still present as some methods may call for specific types/subtypes only.

Updated classes with GetDefaultDropTemplates/GetDefaultLaunchTemplates to use new interface.